### PR TITLE
initial chunk alignment fix

### DIFF
--- a/src/main/native/lib/reader/block_reader.h
+++ b/src/main/native/lib/reader/block_reader.h
@@ -34,6 +34,8 @@ class RemoteBlockReader {
       : stream_(stream)
       , state_(kOpen)
       , options_(options)
+      , chunk_padding_bytes_(0)
+      , checksum_chunk_size_(0)
   {}
 
   template<class MutableBufferSequence, class ReadHandler>
@@ -58,12 +60,14 @@ class RemoteBlockReader {
  private:
   struct ReadPacketHeader;
   struct ReadChecksum;
+  struct ReadPadding;
   template<class MutableBufferSequence>
   struct ReadData;
   struct AckRead;
   enum State {
     kOpen,
     kReadPacketHeader,
+    kReadPadding,
     kReadData,
     kFinished,
   };
@@ -74,8 +78,11 @@ class RemoteBlockReader {
   BlockReaderOptions options_;
   size_t packet_len_;
   size_t packet_read_bytes_;
+  int chunk_padding_bytes_;     //How many bytes to skip when receiving first packet if read offset not aligned to chunk start.
+  std::vector<char> padding_;   //Padding bytes that got sent before start of user requested data.  Keep around to be able to checksum first chunk.
   long long bytes_to_read_;
   std::vector<char> checksum_;
+  int checksum_chunk_size_;
 };
 
 }

--- a/src/test/java/me/haohui/libhdfspp/TestRemoteBlockReader.java
+++ b/src/test/java/me/haohui/libhdfspp/TestRemoteBlockReader.java
@@ -65,4 +65,13 @@ public class TestRemoteBlockReader extends TestRemoteBlockReaderCase {
     LocatedBlock lb = getFirstLocatedBlock();
     testReadBlockCase(lb, readOffset, readLength);
   }
+
+  @Test
+  public void testReadIntoChecksumChunk() throws IOException, InterruptedException {
+    int readLength = BLOCK_SIZE/4;
+    int readOffset = 11;            //offset to middle of checksum chunk, 11 is arbitrarily chosen because it is very unlikely to be the size of a chunk.
+    LocatedBlock lb = getFirstLocatedBlock();
+    testReadBlockCase(lb, readOffset, readLength);
+  }
+
 }


### PR DESCRIPTION
More of a code review and request for feedback than anything; I still want to add some more tests.

Does this look like the right approach?  I could add a "ConsumePadding" monad but adding another small callback inside of ReadData seemed much simpler.

All of the original tests still pass, which doesn't seem right for tests like "testReadAtChecksumBoundary".  From what I can tell they should be failing before or after adding this patch.  I've verified through writing out to the console that this is eating up the padding bytes.  Any insight on why shifting the alignment doesn't seem to effect the tests?  I'm probably overlooking something simple here.
