### PR TITLE
Needed to include algorithm.h to compile base64.cc

### DIFF
--- a/src/main/native/lib/common/base64.cc
+++ b/src/main/native/lib/common/base64.cc
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <functional>
+#include <algorithm>
 
 namespace hdfs {
 


### PR DESCRIPTION
Couldn't compile without algorithm.h.  Might have just set a record for smallest pull request, if you don't mind I'll merge these sorts of things in myself in the future.
