### PR TITLE
Add Standalone Performance/Stress Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,17 @@
         <version>${hadoop.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-hdfs</artifactId>
+        <version>${hadoop.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-hdfs</artifactId>
+        <type>test-jar</type>
+        <version>${hadoop.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>${protobuf.version}</version>
@@ -69,6 +80,16 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
@@ -136,7 +157,9 @@
               <javahPath>${env.JAVA_HOME}/bin/javah</javahPath>
               <javahClassNames>
                 <javahClassName>me.haohui.libhdfspp.NativeIoService</javahClassName>
+                <javahClassName>me.haohui.libhdfspp.NativeRemoteBlockReader</javahClassName>
                 <javahClassName>me.haohui.libhdfspp.NativeRpcEngine</javahClassName>
+                <javahClassName>me.haohui.libhdfspp.NativeTcpConnection</javahClassName>
               </javahClassNames>
               <javahOutputDirectory>${project.build.directory}/libhdfspp/javah</javahOutputDirectory>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,9 @@
             <configuration>
               <javahPath>${env.JAVA_HOME}/bin/javah</javahPath>
               <javahClassNames>
+                <javahClassName>me.haohui.libhdfspp.NativeFileSystem</javahClassName>
                 <javahClassName>me.haohui.libhdfspp.NativeIoService</javahClassName>
+                <javahClassName>me.haohui.libhdfspp.NativeInputStream</javahClassName>
                 <javahClassName>me.haohui.libhdfspp.NativeRemoteBlockReader</javahClassName>
                 <javahClassName>me.haohui.libhdfspp.NativeRpcEngine</javahClassName>
                 <javahClassName>me.haohui.libhdfspp.NativeTcpConnection</javahClassName>

--- a/pom.xml
+++ b/pom.xml
@@ -31,17 +31,118 @@
     <cmake.plugin.version>2.8.11-b4</cmake.plugin.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.11</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-common</artifactId>
+        <version>${hadoop.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-common</artifactId>
+        <type>test-jar</type>
+        <version>${hadoop.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+  </dependencies>
+
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <targetPath>${project.build.directory}/classes</targetPath>
+        <includes>
+          <include>log4j.properties</include>
+        </includes>
+      </resource>
+    </resources>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>native-maven-plugin</artifactId>
+          <version>1.0-alpha-8</version>
+        </plugin>
         <plugin>
           <groupId>com.googlecode.cmake-maven-project</groupId>
           <artifactId>cmake-maven-plugin</artifactId>
           <version>${cmake.plugin.version}</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.1</version>
+          <configuration>
+            <source>1.7</source>
+            <target>1.7</target>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.17</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-maven-plugins</artifactId>
+          <version>${hadoop.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>1.9</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>native-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>javah</goal>
+            </goals>
+            <configuration>
+              <javahPath>${env.JAVA_HOME}/bin/javah</javahPath>
+              <javahClassNames>
+                <javahClassName>me.haohui.libhdfspp.NativeIoService</javahClassName>
+                <javahClassName>me.haohui.libhdfspp.NativeRpcEngine</javahClassName>
+              </javahClassNames>
+              <javahOutputDirectory>${project.build.directory}/libhdfspp/javah</javahOutputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>com.googlecode.cmake-maven-project</groupId>
         <artifactId>cmake-maven-plugin</artifactId>
@@ -71,6 +172,58 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-maven-plugins</artifactId>
+        <executions>
+          <execution>
+            <id>compile-test-protoc</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>protoc</goal>
+            </goals>
+            <configuration>
+              <protocVersion>${protobuf.version}</protocVersion>
+              <imports>
+                <param>${basedir}/src/test/proto</param>
+              </imports>
+              <source>
+                <directory>${basedir}/src/test/proto</directory>
+                <includes>
+                  <include>test_rpc_service.proto</include>
+                </includes>
+              </source>
+              <output>${project.build.directory}/generated-test-sources/java</output>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-test-sources</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-test-sources/java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkMode>once</forkMode>
+          <argLine>-Xmx512m -Djava.library.path=${project.build.directory}/libhdfspp/bindings/java</argLine>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/me/haohui/libhdfspp/IoServiceExecutor.java
+++ b/src/main/java/me/haohui/libhdfspp/IoServiceExecutor.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.haohui.libhdfspp;
+
+import java.io.IOException;
+
+public class IoServiceExecutor implements AutoCloseable {
+  private final NativeIoService ioService;
+  private final Thread worker;
+
+  public IoServiceExecutor(final NativeIoService ioService) {
+    this.ioService = ioService;
+    worker = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        ioService.run();
+      }
+    });
+
+  }
+
+  public void start() {
+    worker.start();
+  }
+
+  @Override
+  public void close() throws IOException, InterruptedException {
+    ioService.stop();
+    worker.join();
+  }
+}

--- a/src/main/java/me/haohui/libhdfspp/NativeFileSystem.java
+++ b/src/main/java/me/haohui/libhdfspp/NativeFileSystem.java
@@ -1,0 +1,38 @@
+package me.haohui.libhdfspp;
+
+import org.apache.hadoop.fs.Path;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+class NativeFileSystem implements Closeable {
+  private final long handle;
+
+  NativeFileSystem(NativeIoService ioService, InetSocketAddress addr)
+      throws IOException {
+    byte[][] s = new byte[1][];
+    this.handle = create(ioService.handle(), addr.getHostString(),
+                         addr.getPort(), s);
+    NativeStatus stat = new NativeStatus(s[0]);
+    stat.checkForIOException();
+  }
+
+  NativeInputStream open(Path path) throws IOException {
+    byte[][] s = new byte[1][];
+    long h = open(handle, path.toString(), s);
+    NativeStatus stat = new NativeStatus(s[0]);
+    stat.checkForIOException();
+    return new NativeInputStream(h);
+  }
+
+  @Override
+  public void close() throws IOException {
+    destroy(handle);
+  }
+
+  private native static long create(long ioService, String server, int port,
+      byte[][] status);
+  private native static long open(long handle, String path, byte[][] status);
+  private native static void destroy(long handle);
+}

--- a/src/main/java/me/haohui/libhdfspp/NativeInputStream.java
+++ b/src/main/java/me/haohui/libhdfspp/NativeInputStream.java
@@ -1,0 +1,34 @@
+package me.haohui.libhdfspp;
+
+import com.google.common.base.Preconditions;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+class NativeInputStream implements Closeable {
+  private final long handle;
+  NativeInputStream(long handle) {
+    this.handle = handle;
+  }
+
+
+  @Override
+  public void close() throws IOException {
+    destroy(handle);
+  }
+
+  int positionRead(ByteBuffer buf, long offset) throws IOException {
+    Preconditions.checkArgument(buf.isDirect());
+    byte[][] s = new byte[1][];
+    int v = positionRead(handle, buf, buf.position(), buf.limit(), offset, s);
+    NativeStatus stat = new NativeStatus(s[0]);
+    stat.checkForIOException();
+    buf.position(buf.position() + v);
+    return v;
+  }
+
+  private native static void destroy(long handle);
+  private native static int positionRead(long handle, ByteBuffer buf,
+      int position, int limit, long offset, byte[][] status);
+}

--- a/src/main/java/me/haohui/libhdfspp/NativeIoService.java
+++ b/src/main/java/me/haohui/libhdfspp/NativeIoService.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.haohui.libhdfspp;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.Exception;
+import java.lang.Override;
+
+class NativeIoService implements Closeable {
+  static {
+    System.loadLibrary("hdfsppjni");
+  }
+
+  private final long handle;
+  long handle() {
+    return handle;
+  }
+
+  NativeIoService() {
+    handle = create();
+  }
+
+  void run() {
+    nativeRun(handle);
+  }
+  void stop() {
+    stop(handle);
+  }
+
+  @Override
+  public void close() throws IOException {
+    stop(handle);
+    destroy(handle);
+  }
+
+  private native static long create();
+  private native static void nativeRun(long handle);
+  private native static void stop(long handle);
+  private native static void destroy(long handle);
+}

--- a/src/main/java/me/haohui/libhdfspp/NativeRemoteBlockReader.java
+++ b/src/main/java/me/haohui/libhdfspp/NativeRemoteBlockReader.java
@@ -1,0 +1,56 @@
+package me.haohui.libhdfspp;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
+import org.apache.hadoop.hdfs.protocolPB.PBHelper;
+import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier;
+import org.apache.hadoop.security.token.Token;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+class NativeRemoteBlockReader implements Closeable {
+  private final long handle;
+
+  NativeRemoteBlockReader(NativeTcpConnection connection) {
+    this.handle = create(connection.handle());
+  }
+
+  long handle() {
+    return handle;
+  }
+
+  void connect(byte[] clientName, Token<DelegationTokenIdentifier> token,
+      ExtendedBlock block, long length, long offset) throws IOException {
+    byte[] tokenBytes = token == null ? null : PBHelper.convert(token)
+        .toByteArray();
+    byte[] blockBytes = PBHelper.convert(block).toByteArray();
+    byte[] stat = connect(handle, clientName, tokenBytes, blockBytes, length,
+                          offset);
+    NativeStatus status = new NativeStatus(stat);
+    status.checkForIOException();
+  }
+
+  int read(ByteBuffer dst) throws IOException {
+    Preconditions.checkArgument(dst.isDirect());
+    byte[][] s = new byte[1][];
+    int v = readSome(handle, dst, dst.position(), dst.limit(), s);
+    NativeStatus stat = new NativeStatus(s[0]);
+    stat.checkForIOException();
+    dst.position(dst.position() + v);
+    return v;
+  }
+
+  @Override
+  public void close() throws IOException {
+    destroy(handle);
+  }
+
+  private native static long create(long connection);
+  private native static void destroy(long handle);
+  private native static byte[] connect(long handle, byte[] clientName, byte[]
+      token, byte[] block, long length, long offset);
+  private native static int readSome(
+      long handle, ByteBuffer dst, int position, int limit, byte[][] status);
+}

--- a/src/main/java/me/haohui/libhdfspp/NativeRpcEngine.java
+++ b/src/main/java/me/haohui/libhdfspp/NativeRpcEngine.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.haohui.libhdfspp;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageLite;
+import org.apache.commons.io.Charsets;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+
+class NativeRpcEngine implements Closeable {
+  private final long handle;
+
+  NativeRpcEngine(NativeIoService ioService, byte[] clientName, String
+      protocol, int version) {
+    handle = create(ioService.handle(), clientName, protocol.getBytes
+        (Charsets.UTF_8), version);
+  }
+
+  void connect(InetSocketAddress addr) throws IOException {
+    byte[] status = connect(handle, addr.getAddress().getHostAddress(),
+                            addr.getPort());
+    NativeStatus stat = new NativeStatus(status);
+    stat.checkForIOException();
+  }
+
+  void startReadLoop() {
+    startReadLoop(handle);
+  }
+
+  void rpc(byte[] method, MessageLite request, MessageLite.Builder response)
+      throws IOException {
+    byte[][] stat = new byte[1][];
+    byte[] resp = rpc(handle, method, request.toByteArray(), stat);
+    if (stat[0] != null) {
+      NativeStatus status = new NativeStatus(stat[0]);
+      status.checkForIOException();
+    }
+    response.clear().mergeFrom(resp);
+  }
+
+  @Override
+  public void close() throws IOException {
+    destroy(handle);
+  }
+
+  private native static long create(long ioService, byte[] clientName, byte[]
+      protocol, int version);
+  private native static byte[] connect(long handle, String host, int port);
+  private native static void startReadLoop(long handle);
+  private native static byte[] rpc(long handle, byte[] method, byte[]
+      request, byte[][] status);
+  private native static void destroy(long handle);
+}

--- a/src/main/java/me/haohui/libhdfspp/NativeStatus.java
+++ b/src/main/java/me/haohui/libhdfspp/NativeStatus.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.haohui.libhdfspp;
+
+import org.apache.commons.io.Charsets;
+
+import java.io.IOException;
+
+class NativeStatus {
+  private final byte[] state;
+
+  NativeStatus(byte[] state) {
+    this.state = state;
+  }
+
+  boolean ok() {
+    return state == null;
+  }
+
+  public void checkForIOException() throws IOException {
+    if (!ok()) {
+      throw new IOException(new String(state, 8, state.length - 8, Charsets
+          .UTF_8));
+    }
+  }
+}

--- a/src/main/java/me/haohui/libhdfspp/NativeTcpConnection.java
+++ b/src/main/java/me/haohui/libhdfspp/NativeTcpConnection.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.haohui.libhdfspp;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+class NativeTcpConnection implements Closeable {
+  private final long handle;
+  long handle() {
+    return handle;
+  }
+
+  NativeTcpConnection(NativeIoService ioService) {
+    handle = create(ioService.handle());
+  }
+
+  void connect(InetSocketAddress addr) throws IOException {
+    byte[] status = connect(handle, addr.getAddress().getHostAddress(),
+                            addr.getPort());
+    NativeStatus stat = new NativeStatus(status);
+    stat.checkForIOException();
+  }
+
+  void disconnect() {
+    disconnect(handle);
+  }
+
+  @Override
+  public void close() throws IOException {
+    disconnect();
+    destroy(handle);
+  }
+
+  private native static long create(long nativeIoService);
+  private native static byte[] connect(long handle, String host, int port);
+  private native static void disconnect(long handle);
+  private native static void destroy(long handle);
+}

--- a/src/main/native/CMakeLists.txt
+++ b/src/main/native/CMakeLists.txt
@@ -14,11 +14,16 @@ include_directories(${JNI_INCLUDE_DIRS})
 endif()
 
 find_package(Protobuf REQUIRED)
+find_package(OpenSSL REQUIRED)
 find_package(Doxygen)
 find_package(Threads)
 
+include_directories(include)
+include_directories(lib)
 include_directories(${PROTOBUF_INCLUDE_DIRS})
 include_directories(${CMAKE_BINARY_DIR}/lib/proto)
+include_directories(third_party/asio-1.10.2/include)
+include_directories(third_party/gtest-1.7.0/include)
 
 add_definitions(-DASIO_STANDALONE)
 if(UNIX)

--- a/src/main/native/CMakeLists.txt
+++ b/src/main/native/CMakeLists.txt
@@ -43,6 +43,7 @@ add_custom_target(doc ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/doc/Doxy
                   COMMENT "Generating API documentation with Doxygen" VERBATIM)
 endif(DOXYGEN_FOUND)
 
+add_subdirectory(bindings/java)
 add_subdirectory(lib)
 
 # Disable warnings for gtest

--- a/src/main/native/bindings/java/CMakeLists.txt
+++ b/src/main/native/bindings/java/CMakeLists.txt
@@ -1,3 +1,3 @@
 include_directories(${CMAKE_BINARY_DIR}/javah)
-add_library(hdfsppjni SHARED io_service.cc rpc.cc)
-target_link_libraries(hdfsppjni rpc common proto ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES})
+add_library(hdfsppjni SHARED block_reader.cc io_service.cc rpc.cc tcp_connection.cc)
+target_link_libraries(hdfsppjni reader rpc common proto ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES})

--- a/src/main/native/bindings/java/CMakeLists.txt
+++ b/src/main/native/bindings/java/CMakeLists.txt
@@ -1,3 +1,5 @@
 include_directories(${CMAKE_BINARY_DIR}/javah)
-add_library(hdfsppjni SHARED block_reader.cc io_service.cc rpc.cc tcp_connection.cc)
-target_link_libraries(hdfsppjni reader rpc common proto ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES})
+add_library(hdfsppjni SHARED
+            block_reader.cc filesystem.cc io_service.cc
+            rpc.cc tcp_connection.cc)
+target_link_libraries(hdfsppjni fs reader rpc common proto ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES})

--- a/src/main/native/bindings/java/CMakeLists.txt
+++ b/src/main/native/bindings/java/CMakeLists.txt
@@ -1,0 +1,3 @@
+include_directories(${CMAKE_BINARY_DIR}/javah)
+add_library(hdfsppjni SHARED io_service.cc rpc.cc)
+target_link_libraries(hdfsppjni rpc common proto ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES})

--- a/src/main/native/bindings/java/bindings.h
+++ b/src/main/native/bindings/java/bindings.h
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef BINDINGS_H_
+#define BINDINGS_H_
+
+#include "libhdfs++/status.h"
+#include "common/util.h"
+
+#include <google/protobuf/message_lite.h>
+
+#include <jni.h>
+
+namespace hdfs {
+
+class StatusHelper {
+ public:
+  static std::pair<const char *, size_t> Rep(const Status &status) {
+    const char *state = status.state_;
+    size_t length = *reinterpret_cast<const uint32_t*>(state);
+    return std::make_pair(state, length + 8);
+  }
+};
+
+}
+
+static inline jbyteArray ToJavaStatusRep(JNIEnv *env, const hdfs::Status &stat) {
+  if (stat.ok()) {
+    return nullptr;
+  }
+
+  auto rep = hdfs::StatusHelper::Rep(stat);
+  jbyteArray arr = env->NewByteArray(rep.second);
+  void *b = env->GetPrimitiveArrayCritical(arr, nullptr);
+  memcpy(b, rep.first, rep.second);
+  env->ReleasePrimitiveArrayCritical(arr, b, 0);
+  return arr;
+}
+
+static inline void SetStatusArray(JNIEnv *env, jobjectArray jstatus, const hdfs::Status &stat) {
+  jbyteArray arr = ToJavaStatusRep(env, stat);
+  env->SetObjectArrayElement(jstatus, 0, arr);
+}
+
+static inline void ReadPBMessage(JNIEnv *env, jbyteArray jbytes, ::google::protobuf::MessageLite *msg) {
+  void *b = env->GetPrimitiveArrayCritical(jbytes, nullptr);
+  msg->ParseFromArray(b, env->GetArrayLength(jbytes));
+  env->ReleasePrimitiveArrayCritical(jbytes, b, JNI_ABORT);
+}
+
+static inline std::string ReadByteString(JNIEnv *env, jbyteArray jbytes) {
+  char *data = reinterpret_cast<char*>(env->GetPrimitiveArrayCritical(jbytes, nullptr));
+  std::string res(data, env->GetArrayLength(jbytes));
+  env->ReleasePrimitiveArrayCritical(jbytes, data, JNI_ABORT);
+  return res;
+}
+
+#endif

--- a/src/main/native/bindings/java/block_reader.cc
+++ b/src/main/native/bindings/java/block_reader.cc
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "bindings.h"
+
+#include "me_haohui_libhdfspp_NativeRemoteBlockReader.h"
+
+#include "libhdfs++/hdfs.h"
+#include "reader/block_reader.h"
+
+#include <asio/ip/tcp.hpp>
+
+using namespace ::hdfs;
+using ::asio::ip::tcp;
+
+JNIEXPORT jlong JNICALL Java_me_haohui_libhdfspp_NativeRemoteBlockReader_create(JNIEnv *, jclass, jlong jconn) {
+  tcp::socket *conn = reinterpret_cast<tcp::socket*>(jconn);
+  auto self = new std::shared_ptr<RemoteBlockReader<tcp::socket> >
+              (new RemoteBlockReader<tcp::socket>(BlockReaderOptions(), conn));
+  return reinterpret_cast<uintptr_t>(self);
+}
+
+JNIEXPORT void JNICALL Java_me_haohui_libhdfspp_NativeRemoteBlockReader_destroy(JNIEnv *, jclass, jlong handle) {
+  delete reinterpret_cast<std::shared_ptr<RemoteBlockReader<tcp::socket> >*>(handle);
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_me_haohui_libhdfspp_NativeRemoteBlockReader_connect(JNIEnv *env, jclass, jlong handle,
+                                                         jbyteArray jclient_name, jbyteArray jtoken,
+                                                         jbyteArray jblock, jlong length, jlong offset) {
+  auto &self = *reinterpret_cast<std::shared_ptr<RemoteBlockReader<tcp::socket> >*>(handle);
+  std::string client_name(ReadByteString(env, jclient_name));
+  hadoop::common::TokenProto token;
+  if (jtoken) {
+    ReadPBMessage(env, jtoken, &token);
+  }
+  hadoop::hdfs::ExtendedBlockProto block;
+  ReadPBMessage(env, jblock, &block);
+  Status stat = self->connect(client_name, jtoken ? &token : nullptr, &block, length, offset);
+  return ToJavaStatusRep(env, stat);
+}
+
+JNIEXPORT jint JNICALL
+Java_me_haohui_libhdfspp_NativeRemoteBlockReader_readSome(JNIEnv *env, jclass, jlong handle, jobject jdst,
+                                                          jint position, jint limit, jobjectArray jstatus) {
+  auto &self = *reinterpret_cast<std::shared_ptr<RemoteBlockReader<tcp::socket> >*>(handle);
+  char *start = reinterpret_cast<char*>(env->GetDirectBufferAddress(jdst));
+  Status stat;
+  if (!start || position > limit) {
+    stat = Status::InvalidArgument("Invalid buffer");
+    SetStatusArray(env, jstatus, stat);
+    return 0;
+  }
+  size_t transferred = self->read_some(asio::buffer(start + position, limit - position), &stat);
+  if (!stat.ok()) {
+    SetStatusArray(env, jstatus, stat);
+  }
+  return transferred;
+}
+

--- a/src/main/native/bindings/java/filesystem.cc
+++ b/src/main/native/bindings/java/filesystem.cc
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "bindings.h"
+
+#include "me_haohui_libhdfspp_NativeFileSystem.h"
+#include "me_haohui_libhdfspp_NativeInputStream.h"
+
+#include "libhdfs++/hdfs.h"
+
+#include <asio/ip/tcp.hpp>
+
+using namespace ::hdfs;
+using ::asio::ip::tcp;
+
+JNIEXPORT jlong JNICALL
+Java_me_haohui_libhdfspp_NativeFileSystem_create(JNIEnv *env, jclass,
+                                                 jlong io_service_handle,
+                                                 jstring jserver,
+                                                 jint port,
+                                                 jobjectArray jstatus) {
+  IoService *io_service = reinterpret_cast<IoService*>(io_service_handle);
+  const char *server = env->GetStringUTFChars(jserver, nullptr);
+  FileSystem *fsptr;
+  Status stat = FileSystem::New(io_service, server, port, &fsptr);
+  jlong result = 0;
+  if (stat.ok()) {
+    result = reinterpret_cast<uintptr_t>(fsptr);
+  } else {
+    SetStatusArray(env, jstatus, stat);
+  }
+
+  env->ReleaseStringUTFChars(jserver, server);
+  return result;
+}
+
+JNIEXPORT jlong JNICALL
+Java_me_haohui_libhdfspp_NativeFileSystem_open(JNIEnv *env, jclass,
+                                               jlong handle,
+                                               jstring jpath,
+                                               jobjectArray jstatus) {
+  FileSystem *self = reinterpret_cast<FileSystem*>(handle);
+  const char *path = env->GetStringUTFChars(jpath, nullptr);
+  InputStream *isptr;
+  Status stat = self->Open(path, &isptr);
+  jlong result = 0;
+  if (stat.ok()) {
+    result = reinterpret_cast<uintptr_t>(isptr);
+  } else {
+    SetStatusArray(env, jstatus, stat);
+  }
+  env->ReleaseStringUTFChars(jpath, path);
+  return result;
+}
+
+JNIEXPORT void JNICALL
+Java_me_haohui_libhdfspp_NativeFileSystem_destroy(JNIEnv *, jclass, jlong handle) {
+  FileSystem *self = reinterpret_cast<FileSystem*>(handle);
+  delete self;
+}
+
+JNIEXPORT void JNICALL
+Java_me_haohui_libhdfspp_NativeInputStream_destroy(JNIEnv *, jclass, jlong handle) {
+  InputStream *self = reinterpret_cast<InputStream*>(handle);
+  delete self;
+}
+
+JNIEXPORT jint JNICALL
+Java_me_haohui_libhdfspp_NativeInputStream_positionRead(JNIEnv *env, jclass,
+                                                        jlong handle,
+                                                        jobject jbuf,
+                                                        jint position,
+                                                        jint limit,
+                                                        jlong offset,
+                                                        jobjectArray jstatus) {
+  InputStream *self = reinterpret_cast<InputStream*>(handle);
+  char *buf = reinterpret_cast<char*>(env->GetDirectBufferAddress(jbuf));
+  Status stat;
+  if (!buf || position > limit) {
+    stat = Status::InvalidArgument("Invalid buffer");
+    SetStatusArray(env, jstatus, stat);
+    return 0;
+  }
+  size_t read_bytes = 0;
+  stat = self->PositionRead(buf + position, limit - position, offset, &read_bytes);
+  if (!stat.ok()) {
+    SetStatusArray(env, jstatus, stat);
+  }
+  return read_bytes;
+}

--- a/src/main/native/bindings/java/io_service.cc
+++ b/src/main/native/bindings/java/io_service.cc
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "bindings.h"
+#include "me_haohui_libhdfspp_NativeIoService.h"
+
+#include "libhdfs++/hdfs.h"
+
+using namespace ::hdfs;
+
+JNIEXPORT jlong JNICALL Java_me_haohui_libhdfspp_NativeIoService_create(JNIEnv *, jclass) {
+  return reinterpret_cast<uintptr_t>(IoService::New());
+}
+
+JNIEXPORT void JNICALL Java_me_haohui_libhdfspp_NativeIoService_nativeRun(JNIEnv *, jclass, jlong handle) {
+  IoService *self = reinterpret_cast<IoService*>(handle);
+  self->Run();
+}
+
+JNIEXPORT void JNICALL Java_me_haohui_libhdfspp_NativeIoService_stop(JNIEnv *, jclass, jlong handle) {
+  IoService *self = reinterpret_cast<IoService*>(handle);
+  self->Stop();
+}
+
+JNIEXPORT void JNICALL Java_me_haohui_libhdfspp_NativeIoService_destroy(JNIEnv *, jclass, jlong handle) {
+  IoService *self = reinterpret_cast<IoService*>(handle);
+  delete self;
+}

--- a/src/main/native/bindings/java/rpc.cc
+++ b/src/main/native/bindings/java/rpc.cc
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "bindings.h"
+
+#include "me_haohui_libhdfspp_NativeRpcEngine.h"
+
+#include "common/wrapper.h"
+#include "common/util.h"
+#include "rpc/rpc_engine.h"
+
+#include <asio/ip/tcp.hpp>
+
+using namespace ::hdfs;
+using ::asio::ip::tcp;
+
+JNIEXPORT jlong JNICALL
+Java_me_haohui_libhdfspp_NativeRpcEngine_create(JNIEnv *env, jclass, jlong io_service_handle,
+                                                jbyteArray jclient_name, jbyteArray jprotocol,
+                                                jint version) {
+  IoServiceImpl *io_service = reinterpret_cast<IoServiceImpl*>(io_service_handle);
+
+  RpcEngine *engine = new RpcEngine(&io_service->io_service(), ReadByteString(env, jclient_name),
+                                    ReadByteString(env, jprotocol).c_str(), version);
+  return reinterpret_cast<uintptr_t>(engine);
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_me_haohui_libhdfspp_NativeRpcEngine_connect(JNIEnv *env, jclass, jlong handle,
+                                                 jstring jhost, jint port) {
+  RpcEngine *self = reinterpret_cast<RpcEngine*>(handle);
+  const char *host = env->GetStringUTFChars(jhost, nullptr);
+  tcp::endpoint ep(asio::ip::address::from_string(host), port);
+  Status status = self->Connect(ep);
+  env->ReleaseStringUTFChars(jhost, host);
+  return ToJavaStatusRep(env, status);
+}
+
+JNIEXPORT void JNICALL
+Java_me_haohui_libhdfspp_NativeRpcEngine_startReadLoop(JNIEnv *, jclass, jlong handle) {
+  RpcEngine *self = reinterpret_cast<RpcEngine*>(handle);
+  self->StartReadLoop();
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_me_haohui_libhdfspp_NativeRpcEngine_rpc(JNIEnv *env, jclass, jlong handle, jbyteArray jmethod,
+                                             jbyteArray request, jobjectArray jstatus) {
+  RpcEngine *self = reinterpret_cast<RpcEngine*>(handle);
+  auto response = std::make_shared<std::string>();
+  Status stat = self->RawRpc(ReadByteString(env, jmethod),
+                             std::move(ReadByteString(env, request)), response);
+  if (!stat.ok()) {
+    SetStatusArray(env, jstatus, stat);
+    return nullptr;
+  }
+  jbyteArray jresp = env->NewByteArray(response->size());
+  void *b = env->GetPrimitiveArrayCritical(jresp, nullptr);
+  memcpy(b, response->c_str(), response->size());
+  env->ReleasePrimitiveArrayCritical(jresp, b, 0);
+  return jresp;
+}
+
+JNIEXPORT void JNICALL Java_me_haohui_libhdfspp_NativeRpcEngine_destroy(JNIEnv *, jclass, jlong handle) {
+  delete reinterpret_cast<RpcEngine*>(handle);
+}

--- a/src/main/native/bindings/java/tcp_connection.cc
+++ b/src/main/native/bindings/java/tcp_connection.cc
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "bindings.h"
+#include "me_haohui_libhdfspp_NativeTcpConnection.h"
+#include "common/wrapper.h"
+
+#include <asio/ip/tcp.hpp>
+
+using namespace ::hdfs;
+using ::asio::ip::tcp;
+
+JNIEXPORT jlong JNICALL Java_me_haohui_libhdfspp_NativeTcpConnection_create(JNIEnv *, jclass, jlong io_service_handle) {
+  IoServiceImpl *io_service = reinterpret_cast<IoServiceImpl*>(io_service_handle);
+  tcp::socket *sock = new tcp::socket(io_service->io_service());
+  return reinterpret_cast<uintptr_t>(sock);
+}
+
+JNIEXPORT jbyteArray JNICALL Java_me_haohui_libhdfspp_NativeTcpConnection_connect(JNIEnv *env, jclass, jlong handle, jstring jhost, jint port) {
+  tcp::socket *self = reinterpret_cast<tcp::socket*>(handle);
+  const char *host = env->GetStringUTFChars(jhost, nullptr);
+  tcp::endpoint ep(asio::ip::address::from_string(host), port);
+  asio::error_code ec;
+  self->connect(ep, ec);
+  env->ReleaseStringUTFChars(jhost, host);
+  if (!ec) {
+    return nullptr;
+  }
+  assert (false && "Unimplemented");
+}
+
+JNIEXPORT void JNICALL Java_me_haohui_libhdfspp_NativeTcpConnection_disconnect(JNIEnv *, jclass, jlong handle) {
+  tcp::socket *self = reinterpret_cast<tcp::socket*>(handle);
+  ::asio::error_code ec;
+  self->close(ec);
+}
+
+JNIEXPORT void JNICALL Java_me_haohui_libhdfspp_NativeTcpConnection_destroy(JNIEnv *, jclass, jlong handle) {
+  tcp::socket *self = reinterpret_cast<tcp::socket*>(handle);
+  delete self;
+}

--- a/src/main/native/doc/Doxyfile.in
+++ b/src/main/native/doc/Doxyfile.in
@@ -6,7 +6,10 @@ MARKDOWN_SUPPORT       = YES
 BUILTIN_STL_SUPPORT    = YES
 
 
-INPUT                  = @CMAKE_SOURCE_DIR@/doc/mainpage.dox
+INPUT                  = @CMAKE_SOURCE_DIR@/doc/mainpage.dox \
+                         @CMAKE_SOURCE_DIR@/include/libhdfs++ \
+                         @CMAKE_SOURCE_DIR@/lib/common/continuation \
+
 INPUT_ENCODING         = UTF-8
 RECURSIVE              = NO
 

--- a/src/main/native/include/libhdfs++/chdfs.h
+++ b/src/main/native/include/libhdfs++/chdfs.h
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//  Expose a pure C interface that doesn't need any C++/C++11 header files, designed to be compatible with
+//  libhdfs and libhdfs3 C APIs.  
+//
+//  This is still a work in progress and only contains a subset of the function calls in libhdfs/libhdfs3 for now.
+//
+
+#ifndef INCLUDE_LIBHDFSPP_CHDFS_H_
+#define INCLUDE_LIBHDFSPP_CHDFS_H
+
+#include "stdlib.h"
+
+struct hdfsFile_struct;
+struct hdfsFS_struct;
+
+typedef hdfsFS_struct*   hdfsFS;
+typedef hdfsFile_struct* hdfsFile;
+
+
+/*  Library initialization routine
+ *    -need to start background thread(s) to run asio::io_service
+ *    -connect to specified namenode host:port
+ *    -this will need to be extended to allow application to control memory management routines
+ *     by passing an allocator/deleter pair as well as specify io_service thread count 
+ */
+extern "C" {
+  hdfsFS hdfsConnect(const char *nnhost, unsigned short nnport);
+}
+
+
+/** 
+ * hdfsDisconnect - Disconnect from the hdfs file system.
+ * Disconnect from hdfs.
+ * @param fs The configured filesystem handle.
+ * @return Returns 0 on success, -1 on error.  
+ */
+extern "C" {
+  int hdfsDisconnect(hdfsFS fs);
+}
+
+
+/* hdfsOpenFile - Open an hdfs file in given mode **read only for now**
+ * @param fs    The configured filesystem handle
+ * @param path  The absolute path to the file
+ * @param flags Ignored, assumes O_RDONLY
+ * @param bufferSize  ignored - not implemented
+ * @param replication ignored - not implemented
+ * @param blockSize   ignored - not implemented
+ */
+extern "C" {
+  hdfsFile hdfsOpenFile(hdfsFS fs, const char *path, int flags, int bufferSize, short replication, int blockSize);
+}
+
+
+/** 
+ * hdfsCloseFile - Close an open file. 
+ * @param fs The configured filesystem handle.
+ * @param file The file handle.
+ * @return Returns 0 on success, -1 on error.  
+ */
+extern "C" {
+  int hdfsCloseFile(hdfsFS fs, hdfsFile file);
+}
+
+
+/** 
+ * hdfsPread - Positional read of data from an open file.
+ * @param fs The configured filesystem handle.
+ * @param file The file handle.
+ * @param position Position from which to read
+ * @param buffer The buffer to copy read bytes into.
+ * @param length The length of the buffer.
+ * @return Returns the number of bytes actually read, possibly less than
+ * than length;-1 on error.
+ */
+extern "C" {
+  size_t hdfsPread(hdfsFS fs, hdfsFile file, off_t position, void *buf, size_t length);
+}
+
+/*  todo, roughly in order of priority, before write path is complete
+ *    tSize hdfsRead(hdfsFS fs, hdfsFile file, void* buffer, tSize length);
+ *    int hdfsExists(hdfsFS fs, const char *path);
+ *    int hdfsSeek(hdfsFS fs, hdfsFile file, tOffset desiredPos);
+ *    tOffset hdfsTell(hdfsFS fs, hdfsFile file);
+ *
+ */
+
+#endif
+

--- a/src/main/native/include/libhdfs++/chdfs.h
+++ b/src/main/native/include/libhdfs++/chdfs.h
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//  Expose a pure C interface that doesn't need any C++/C++11 header files, designed to be compatible with
+//  libhdfs and libhdfs3 C APIs.  
+//
+//  This is still a work in progress and only contains a subset of the function calls in libhdfs/libhdfs3 for now.
+//
+
+#ifndef INCLUDE_LIBHDFSPP_CHDFS_H_
+#define INCLUDE_LIBHDFSPP_CHDFS_H_
+
+#include "stdlib.h"
+
+struct hdfsFile_struct;
+struct hdfsFS_struct;
+
+typedef hdfsFS_struct*   hdfsFS;
+typedef hdfsFile_struct* hdfsFile;
+
+
+/*  Library initialization routine
+ *    -need to start background thread(s) to run asio::io_service
+ *    -connect to specified namenode host:port
+ *    -this will need to be extended to allow application to control memory management routines
+ *     by passing an allocator/deleter pair as well as specify io_service thread count 
+ */
+extern "C" {
+  hdfsFS hdfsConnect(const char *nnhost, unsigned short nnport);
+}
+
+
+/** 
+ * hdfsDisconnect - Disconnect from the hdfs file system.
+ * Disconnect from hdfs.
+ * @param fs The configured filesystem handle.
+ * @return Returns 0 on success, -1 on error.  
+ */
+extern "C" {
+  int hdfsDisconnect(hdfsFS fs);
+}
+
+
+/* hdfsOpenFile - Open an hdfs file in given mode **read only for now**
+ * @param fs    The configured filesystem handle
+ * @param path  The absolute path to the file
+ * @param flags Ignored, assumes O_RDONLY
+ * @param bufferSize  ignored - not implemented
+ * @param replication ignored - not implemented
+ * @param blockSize   ignored - not implemented
+ */
+extern "C" {
+  hdfsFile hdfsOpenFile(hdfsFS fs, const char *path, int flags, int bufferSize, short replication, int blockSize);
+}
+
+
+/** 
+ * hdfsCloseFile - Close an open file. 
+ * @param fs The configured filesystem handle.
+ * @param file The file handle.
+ * @return Returns 0 on success, -1 on error.  
+ */
+extern "C" {
+  int hdfsCloseFile(hdfsFS fs, hdfsFile file);
+}
+
+
+/** 
+ * hdfsPread - Positional read of data from an open file.
+ * @param fs The configured filesystem handle.
+ * @param file The file handle.
+ * @param position Position from which to read
+ * @param buffer The buffer to copy read bytes into.
+ * @param length The length of the buffer.
+ * @return Returns the number of bytes actually read, possibly less than
+ * than length;-1 on error.
+ */
+extern "C" {
+  size_t hdfsPread(hdfsFS fs, hdfsFile file, off_t position, void *buf, size_t length);
+}
+
+#endif
+

--- a/src/main/native/include/libhdfs++/hdfs.h
+++ b/src/main/native/include/libhdfs++/hdfs.h
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LIBHDFSPP_HDFS_H_
+#define LIBHDFSPP_HDFS_H_
+
+#include "libhdfs++/status.h"
+
+namespace hdfs {
+
+class IoService {
+ public:
+  static IoService *New();
+  virtual void Run() = 0;
+  virtual void Stop() = 0;
+  virtual ~IoService();
+};
+
+}
+
+#endif

--- a/src/main/native/include/libhdfs++/options.h
+++ b/src/main/native/include/libhdfs++/options.h
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LIBHDFSPP_OPTIONS_H_
+#define LIBHDFSPP_OPTIONS_H_
+
+#include <string>
+
+namespace hdfs {
+
+struct CacheStrategy {
+  bool drop_behind_specified;
+  bool drop_behind;
+  bool read_ahead_specified;
+  unsigned long long read_ahead;
+  CacheStrategy()
+      : drop_behind_specified(false)
+      , drop_behind(false)
+      , read_ahead_specified(false)
+      , read_ahead(false)
+  {}
+};
+
+enum DropBehindStrategy {
+  kUnspecified = 0,
+  kEnableDropBehind  = 1,
+  kDisableDropBehind = 2,
+};
+
+enum EncryptionScheme {
+  kNone = 0,
+  kAESCTRNoPadding = 1,
+};
+
+struct BlockReaderOptions {
+  bool verify_checksum;
+  CacheStrategy cache_strategy;
+  EncryptionScheme encryption_scheme;
+
+  BlockReaderOptions()
+      : verify_checksum(true)
+      , encryption_scheme(EncryptionScheme::kNone)
+  {}
+};
+
+}
+
+#endif

--- a/src/main/native/include/libhdfs++/status.h
+++ b/src/main/native/include/libhdfs++/status.h
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LIBHDFSPP_STATUS_H_
+#define LIBHDFSPP_STATUS_H_
+
+#include <string>
+#include <system_error>
+
+namespace hdfs {
+
+class StatusHelper;
+class Status {
+ public:
+  // Create a success status.
+  Status() : state_(NULL) { }
+  ~Status() { delete[] state_; }
+  explicit Status(int code, const char *msg);
+
+  // Copy the specified status.
+  Status(const Status& s);
+  void operator=(const Status& s);
+
+  // Return a success status.
+  static Status OK() { return Status(); }
+  static Status InvalidArgument(const char *msg)
+  { return Status(kInvalidArgument, msg); }
+  static Status ResourceUnavailable(const char *msg)
+  { return Status(kResourceUnavailable, msg); }
+  static Status Unimplemented()
+  { return Status(kUnimplemented, ""); }
+  static Status Error(const char *msg)
+  { return Status(kGenericError, msg); }
+  static Status InvalidEncryptionKey(const char *msg)
+  { return Status(kInvalidEncryptionKey, msg); }
+  static Status Exception(const char *expception_class_name, const char *error_message)
+  { return Status(kException, expception_class_name, error_message); }
+
+  // Returns true iff the status indicates success.
+  bool ok() const { return (state_ == NULL); }
+
+  // Return a string representation of this status suitable for printing.
+  // Returns the string "OK" for success.
+  std::string ToString() const;
+
+  int code() const {
+    return (state_ == NULL) ? kOk : static_cast<int>(state_[4]);
+  }
+
+ private:
+  // OK status has a NULL state_.  Otherwise, state_ is a new[] array
+  // of the following form:
+  //    state_[0..3] == length of message
+  //    state_[4]    == code
+  //    state_[5..]  == message
+  const char* state_;
+  friend class StatusHelper;
+
+  enum Code {
+    kOk = 0,
+    kInvalidArgument = static_cast<unsigned>(std::errc::invalid_argument),
+    kResourceUnavailable = static_cast<unsigned>(std::errc::resource_unavailable_try_again),
+    kGenericError = 1,
+    kInvalidEncryptionKey = 2,
+    kUnimplemented = 3,
+    kException = 256,
+  };
+
+  explicit Status(int code, const char *msg1, const char *msg2);
+  static const char *CopyState(const char* s);
+  static const char *ConstructState(int code, const char *msg1, const char *msg2);
+};
+
+inline Status::Status(const Status& s) {
+  state_ = (s.state_ == NULL) ? NULL : CopyState(s.state_);
+}
+
+inline void Status::operator=(const Status& s) {
+  // The following condition catches both aliasing (when this == &s),
+  // and the common case where both s and *this are ok.
+  if (state_ != s.state_) {
+    delete[] state_;
+    state_ = (s.state_ == NULL) ? NULL : CopyState(s.state_);
+  }
+}
+
+}
+
+#endif

--- a/src/main/native/lib/CMakeLists.txt
+++ b/src/main/native/lib/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(common)
+add_subdirectory(fs)
 add_subdirectory(reader)
 add_subdirectory(rpc)
 add_subdirectory(proto)

--- a/src/main/native/lib/CMakeLists.txt
+++ b/src/main/native/lib/CMakeLists.txt
@@ -1,2 +1,4 @@
+add_subdirectory(common)
+add_subdirectory(rpc)
 add_subdirectory(proto)
 

--- a/src/main/native/lib/CMakeLists.txt
+++ b/src/main/native/lib/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(common)
+add_subdirectory(reader)
 add_subdirectory(rpc)
 add_subdirectory(proto)
 

--- a/src/main/native/lib/common/CMakeLists.txt
+++ b/src/main/native/lib/common/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(common base64.cc status.cc)

--- a/src/main/native/lib/common/CMakeLists.txt
+++ b/src/main/native/lib/common/CMakeLists.txt
@@ -1,1 +1,5 @@
-add_library(common hdfs.cc base64.cc status.cc)
+add_library(common hdfs.cc base64.cc datatransfer_sasl.cc sasl_digest_md5.cc status.cc)
+add_executable(sasl_digest_md5_test sasl_digest_md5_test.cc)
+target_link_libraries(sasl_digest_md5_test common ${OPENSSL_LIBRARIES} gtest_main)
+add_test(sasl_digest_md5_test sasl_digest_md5_test)
+

--- a/src/main/native/lib/common/CMakeLists.txt
+++ b/src/main/native/lib/common/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_library(common base64.cc status.cc)
+add_library(common hdfs.cc base64.cc status.cc)

--- a/src/main/native/lib/common/base64.cc
+++ b/src/main/native/lib/common/base64.cc
@@ -1,0 +1,62 @@
+#include "util.h"
+
+#include <array>
+#include <functional>
+
+namespace hdfs {
+
+std::string Base64Encode(const std::string &src) {
+  static const char kDictionary[] =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      "abcdefghijklmnopqrstuvwxyz"
+      "0123456789+/";
+
+  int encoded_size = (src.size() + 2) / 3 * 4;
+  std::string dst;
+  dst.reserve(encoded_size);
+
+  size_t i = 0;
+  while (i + 3 < src.length()) {
+    const char *s = &src[i];
+    const int r[4] = {
+      s[0] >> 2,
+      ((s[0] << 4) | (s[1] >> 4)) & 0x3f,
+      ((s[1] << 2) | (s[2] >> 6)) & 0x3f,
+      s[2] & 0x3f };
+
+    std::transform(r, r + sizeof(r) / sizeof(int), std::back_inserter(dst),
+                   [&r](unsigned char v) { return kDictionary[v]; });
+    i += 3;
+  }
+
+  size_t remained = src.length() - i;
+  const char *s = &src[i];
+
+  switch (remained) {
+    case 0:
+      break;
+    case 1: {
+      char padding[4] = {
+        kDictionary[s[0] >> 2],
+        kDictionary[(s[0] << 4) & 0x3f],
+        '=', '=' };
+      dst.append(padding, sizeof(padding));
+    }
+      break;
+    case 2: {
+      char padding[4] = {
+        kDictionary[src[i] >> 2],
+        kDictionary[((s[0] << 4) | (s[1] >> 4)) & 0x3f],
+        kDictionary[(s[1] << 2) & 0x3f],
+        '=' };
+      dst.append(padding, sizeof(padding));
+    }
+      break;
+    default:
+      assert("Unreachable");
+      break;
+  }
+  return dst;
+}
+
+}

--- a/src/main/native/lib/common/base64.cc
+++ b/src/main/native/lib/common/base64.cc
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <functional>
+#include <algorithm>
 
 namespace hdfs {
 

--- a/src/main/native/lib/common/continuation/asio.h
+++ b/src/main/native/lib/common/continuation/asio.h
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LIB_COMMON_COROUTINES_ASIO_H_
+#define LIB_COMMON_COROUTINES_ASIO_H_
+
+#include "continuation.h"
+#include "common/util.h"
+
+#include "libhdfs++/status.h"
+
+#include <asio/connect.hpp>
+#include <asio/read.hpp>
+#include <asio/write.hpp>
+#include <asio/ip/tcp.hpp>
+
+namespace hdfs {
+namespace continuation {
+
+template<class Stream, class MutableBufferSequence>
+class ReadContinuation : public Continuation {
+ public:
+  ReadContinuation(Stream *stream, const MutableBufferSequence &buffer)
+      : stream_(stream)
+      , buffer_(buffer)
+  {}
+  virtual void Run(const Next& next) override {
+    auto handler = [next](const asio::error_code &ec, size_t)
+                   { next(ToStatus(ec)); };
+    asio::async_read(*stream_, buffer_, handler);
+  }
+
+ private:
+  Stream *stream_;
+  MutableBufferSequence buffer_;
+};
+
+template<class Stream, class ConstBufferSequence>
+class WriteContinuation : public Continuation {
+ public:
+  WriteContinuation(Stream *stream, const ConstBufferSequence& buffer)
+      : stream_(stream)
+      , buffer_(buffer)
+  {}
+  
+  virtual void Run(const Next& next) override {
+    auto handler = [next](const asio::error_code &ec, size_t)
+                   { next(ToStatus(ec)); };
+    asio::async_write(*stream_, buffer_, handler);
+  }
+
+ private:
+  Stream *stream_;
+  ConstBufferSequence buffer_;
+};
+
+template<class Socket, class Iterator>
+class ConnectContinuation : public Continuation {
+ public:
+  ConnectContinuation(Socket *socket, Iterator begin, Iterator end,
+                   Iterator *connected_endpoint)
+      : socket_(socket)
+      , begin_(begin)
+      , end_(end)
+      , connected_endpoint_(connected_endpoint)
+  {}
+
+  virtual void Run(const Next& next) override {
+    auto handler = [this,next](const asio::error_code &ec, Iterator it) {
+      if (connected_endpoint_) {
+        *connected_endpoint_ = it;
+      }
+      next(ToStatus(ec));
+    };
+    asio::async_connect(*socket_, begin_, end_, handler);
+  }
+ private:
+  Socket *socket_;
+  Iterator begin_;
+  Iterator end_;
+  Iterator *connected_endpoint_;
+};
+
+template<class Stream, class ConstBufferSequence>
+static inline Continuation* Write(Stream *stream, const ConstBufferSequence &buffer) {
+  return new WriteContinuation<Stream, ConstBufferSequence>(stream, buffer);
+}
+
+template<class Stream, class MutableBufferSequence>
+static inline Continuation* Read(Stream *stream, const MutableBufferSequence &buffer) {
+  return new ReadContinuation<Stream, MutableBufferSequence>(stream, buffer);
+}
+
+template<class Socket, class Iterator>
+static inline Continuation* Connect(Socket *socket, Iterator begin, Iterator end) {
+  return new ConnectContinuation<Socket, Iterator>(socket, begin, end, nullptr);
+}
+
+}
+}
+
+#endif

--- a/src/main/native/lib/common/continuation/continuation.h
+++ b/src/main/native/lib/common/continuation/continuation.h
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LIB_COMMON_CONTINUATION_CONTINUATION_H_
+#define LIB_COMMON_CONTINUATION_CONTINUATION_H_
+
+#include "libhdfs++/status.h"
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace hdfs {
+namespace continuation {
+
+class PipelineBase;
+
+/**
+ * A continuation is a fragment of runnable code whose execution will
+ * be scheduled by a \link Pipeline \endlink.
+ *
+ * The Continuation class is a build block to implement the
+ * Continuation Passing Style (CPS) in libhdfs++. In CPS, the
+ * upper-level user specifies the control flow by chaining a sequence
+ * of continuations explicitly through the \link Run() \endlink method,
+ * while in traditional imperative programming the sequences of
+ * sentences implicitly specify the control flow.
+ *
+ * See http://en.wikipedia.org/wiki/Continuation for more details.
+ **/
+class Continuation {
+ public:
+  typedef std::function<void(const Status &)> Next;
+  virtual ~Continuation() = default;
+  virtual void Run(const Next &next) = 0;
+  Continuation(const Continuation &) = delete;
+  Continuation &operator=(const Continuation &) = delete;
+ protected:
+  Continuation() = default;
+};
+
+/**
+ * A pipeline schedules the execution of a chain of \link Continuation
+ * \endlink. The pipeline schedules the execution of continuations
+ * based on their order in the pipeline, where the next parameter for
+ * each continuation points to the \link Schedule() \endlink
+ * method. That way the pipeline executes all scheduled continuations
+ * in sequence.
+ *
+ * The typical use case of a pipeline is executing continuations
+ * asynchronously. Note that a continuation calls the next
+ * continuation when it is finished. If the continuation is posted
+ * into an asynchronous event loop, invoking the next continuation
+ * can be done in the callback handler in the asynchronous event loop.
+ *
+ * The pipeline allocates the memory as follows. A pipeline is always
+ * allocated on the heap. It owns all the continuations as well as the
+ * the state specified by the user. Both the continuations and the
+ * state have the same life cycle of the pipeline. The design
+ * simplifies the problem of ensuring that the executions in the
+ * asynchronous event loop always hold valid pointers w.r.t. the
+ * pipeline. The pipeline will automatically deallocate itself right
+ * after it invokes the callback specified the user.
+ **/
+template<class State>
+class Pipeline {
+ public:
+  typedef std::function<void(const Status &, const State &)> UserHandler;
+  static Pipeline *Create() { return new Pipeline(); }
+  Pipeline &Push(Continuation *stage);
+  void Run(UserHandler &&handler);
+  State &state() { return state_; }
+
+ private:
+  State state_;
+  std::vector<std::unique_ptr<Continuation> > routines_;
+  size_t stage_;
+  std::function<void(const Status &, const State &)> handler_;
+
+  Pipeline() : stage_(0) {}
+  ~Pipeline() = default;
+  void Schedule(const Status &status);
+};
+
+template<class State>
+inline Pipeline<State> &Pipeline<State>::Push(Continuation *stage) {
+  routines_.emplace_back(std::unique_ptr<Continuation>(stage));
+  return *this;
+}
+
+template<class State>
+inline void Pipeline<State>::Schedule(const Status &status) {
+  if (stage_ >= routines_.size()) {
+    handler_(status, state_);
+    routines_.clear();
+    delete this;
+  } else {
+    auto next = routines_[stage_].get();
+    ++stage_;
+    next->Run(std::bind(&Pipeline::Schedule, this, std::placeholders::_1));
+  }
+}
+
+template<class State>
+inline void Pipeline<State>::Run(UserHandler &&handler) {
+  handler_ = std::move(handler);
+  Schedule(Status::OK());
+}
+
+}
+}
+
+#endif

--- a/src/main/native/lib/common/continuation/protobuf.h
+++ b/src/main/native/lib/common/continuation/protobuf.h
@@ -1,0 +1,113 @@
+#ifndef LIBHDFSPP_COMMON_COROUTINES_PROTOBUF_H_
+#define LIBHDFSPP_COMMON_COROUTINES_PROTOBUF_H_
+
+#include "common/util.h"
+
+#include <google/protobuf/message_lite.h>
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+
+#include <cassert>
+
+namespace hdfs {
+namespace continuation {
+
+template <class Stream, size_t MaxMessageSize = 512>
+struct ReadDelimitedPBMessageContinuation : public Continuation {
+  ReadDelimitedPBMessageContinuation(Stream *stream, ::google::protobuf::MessageLite *msg)
+      : stream_(stream)
+      , msg_(msg)
+  {}
+  
+  virtual void Run(const Next& next) override {
+    namespace pbio = google::protobuf::io;
+    auto handler = [this,next](const asio::error_code &ec, size_t) {
+      Status status;
+      if (ec) {
+        status = ToStatus(ec);
+      } else {
+        pbio::ArrayInputStream as(&buf_[0], buf_.size());
+        pbio::CodedInputStream is(&as);
+        uint32_t size = 0;
+        bool v = is.ReadVarint32(&size);
+        assert(v);
+        is.PushLimit(size);
+        msg_->Clear();
+        v = msg_->MergeFromCodedStream(&is);
+        assert(v);
+      }
+      next(status);
+    };
+    asio::async_read(
+        *stream_, asio::buffer(buf_),
+        std::bind(&ReadDelimitedPBMessageContinuation::CompletionHandler, this,
+                  std::placeholders::_1, std::placeholders::_2),
+        handler);
+  }
+
+ private:
+  size_t CompletionHandler(const asio::error_code &ec, size_t transferred) {
+    if (ec) {
+      return 0;
+    }
+
+    size_t offset = 0, len = 0;
+    for (size_t i = 0; i + 1 < transferred && i < sizeof(int); ++i) {
+      len = (len << 7) | (buf_[i] & 0x7f);
+      if ((uint8_t)buf_.at(i) < 0x80) {
+        offset = i + 1;
+        break;
+      }
+    }
+
+    assert (offset + len < buf_.size() && "Message is too big");
+    return offset ? len + offset - transferred : 1;
+  }
+
+  Stream *stream_;
+  ::google::protobuf::MessageLite *msg_;
+  std::array<char, MaxMessageSize> buf_;
+};
+
+template <class Stream>
+struct WriteDelimitedPBMessageContinuation : Continuation {
+  WriteDelimitedPBMessageContinuation(
+      Stream *stream, const google::protobuf::MessageLite *msg)
+      : stream_(stream)
+      , msg_(msg)
+  {}
+
+  virtual void Run(const Next& next) override {
+    namespace pbio = google::protobuf::io;
+    int size = msg_->ByteSize();
+    buf_.reserve(pbio::CodedOutputStream::VarintSize32(size) + size);
+    pbio::StringOutputStream ss(&buf_);
+    pbio::CodedOutputStream os(&ss);
+    os.WriteVarint32(size);
+    msg_->SerializeToCodedStream(&os);
+    write_coroutine_ = std::shared_ptr<Continuation>(Write(stream_, asio::buffer(buf_)));
+    write_coroutine_->Run([next](const Status &stat) { next(stat); });
+  }
+
+ private:
+  Stream *stream_;
+  const google::protobuf::MessageLite * msg_;
+  std::string buf_;
+  std::shared_ptr<Continuation> write_coroutine_;
+};
+
+template<class Stream, size_t MaxMessageSize = 512>
+static inline Continuation*
+ReadDelimitedPBMessage(Stream *stream, ::google::protobuf::MessageLite *msg) {
+  return new ReadDelimitedPBMessageContinuation<Stream, MaxMessageSize>(stream, msg);
+}
+
+template<class Stream>
+static inline Continuation*
+WriteDelimitedPBMessage(Stream *stream, ::google::protobuf::MessageLite *msg) {
+  return new WriteDelimitedPBMessageContinuation<Stream>(stream, msg);
+}
+
+}
+}
+#endif

--- a/src/main/native/lib/common/datatransfer.h
+++ b/src/main/native/lib/common/datatransfer.h
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef COMMON_DATA_TRANSFER_H_
+#define COMMON_DATA_TRANSFER_H_
+
+namespace hdfs {
+
+enum {
+  kDataTransferVersion = 28,
+  kDataTransferSasl = 0xdeadbeef,
+};
+
+enum Operation {
+  kWriteBlock = 80,
+  kReadBlock  = 81,
+};
+
+}
+
+#endif

--- a/src/main/native/lib/common/datatransfer_sasl.cc
+++ b/src/main/native/lib/common/datatransfer_sasl.cc
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "datatransfer_sasl.h"
+
+#include "libhdfs++/status.h"
+
+namespace hdfs {
+
+namespace DataTransferSaslStreamUtil {
+
+static const auto kSUCCESS = hadoop::hdfs::DataTransferEncryptorMessageProto_DataTransferEncryptorStatus_SUCCESS;
+
+Status ConvertToStatus(const SaslMessage *msg, std::string *payload) {
+  using namespace hadoop::hdfs;
+  auto s = msg->status();
+  if (s == DataTransferEncryptorMessageProto_DataTransferEncryptorStatus_ERROR_UNKNOWN_KEY) {
+    payload->clear();
+    return Status::InvalidEncryptionKey(msg->message().c_str());
+  } else if (s == DataTransferEncryptorMessageProto_DataTransferEncryptorStatus_ERROR) {
+    payload->clear();
+    return Status::Error(msg->message().c_str());
+  } else {
+    *payload = msg->payload();
+    return Status::OK();
+  }
+}
+
+void PrepareInitialHandshake(SaslMessage *msg) {
+  msg->set_status(kSUCCESS);
+  msg->set_payload("");
+}
+
+}
+}

--- a/src/main/native/lib/common/datatransfer_sasl.h
+++ b/src/main/native/lib/common/datatransfer_sasl.h
@@ -1,0 +1,180 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef COMMON_DATATRANSFER_SASL_H_
+#define COMMON_DATATRANSFER_SASL_H_
+
+#include "sasl_authenticator.h"
+#include "common/continuation/asio.h"
+#include "common/continuation/protobuf.h"
+
+#include "libhdfs++/options.h"
+
+#include "datatransfer.h"
+#include "datatransfer.pb.h"
+
+namespace hdfs {
+
+template <class Stream>
+class DataTransferSaslStream {
+ public:
+  DataTransferSaslStream(const BlockReaderOptions &options,
+                         const std::shared_ptr<Stream> &stream,
+                         const std::string &username,
+                         const std::string &password)
+      : stream_(stream)
+      , options_(options)
+      , authenticator_(username, password)
+  {}
+
+  template<class Handler>
+  void Handshake(const Handler &next);
+
+  template <typename MutableBufferSequence, typename ReadHandler>
+  ASIO_INITFN_RESULT_TYPE(ReadHandler,
+      void (asio::error_code, std::size_t))
+  async_read_some(const MutableBufferSequence& buffers,
+                  ASIO_MOVE_ARG(ReadHandler) handler) {
+    return stream_->async_read_some(buffers, handler);
+  }
+
+  template <typename ConstBufferSequence, typename WriteHandler>
+  ASIO_INITFN_RESULT_TYPE(WriteHandler,
+      void (asio::error_code, std::size_t))
+  async_write_some(const ConstBufferSequence& buffers,
+      ASIO_MOVE_ARG(WriteHandler) handler)
+  {
+    return stream_->async_write_some(buffers, handler);
+  }
+
+ private:
+  DataTransferSaslStream(const DataTransferSaslStream&) = delete;
+  DataTransferSaslStream &operator=(const DataTransferSaslStream &) = delete;
+  std::shared_ptr<Stream> stream_;
+  BlockReaderOptions options_;
+  DigestMD5Authenticator authenticator_;
+  struct ReadSaslMessageContinuation;
+  struct AuthenticatorContinuation;
+};
+
+namespace DataTransferSaslStreamUtil {
+
+typedef hadoop::hdfs::DataTransferEncryptorMessageProto SaslMessage;
+
+Status ConvertToStatus(const SaslMessage *msg, std::string *payload);
+void PrepareInitialHandshake(SaslMessage *msg);
+
+}
+
+template<class Stream>
+struct DataTransferSaslStream<Stream>::AuthenticatorContinuation
+    : continuation::Continuation {
+  AuthenticatorContinuation(DigestMD5Authenticator *authenticator,
+                     BlockReaderOptions *options,
+                     const std::string *request,
+                     hadoop::hdfs::DataTransferEncryptorMessageProto *msg)
+      : authenticator_(authenticator)
+      , options_(options)
+      , request_(request)
+      , msg_(msg)
+  {}
+
+  virtual void Run(const Next& next) override {
+    std::string response;
+    Status status = authenticator_->EvaluateResponse(*request_, &response);
+    msg_->Clear();
+    if (status.ok()) {
+      // TODO: Handle encryption scheme
+      msg_->set_payload(response);
+      msg_->set_status(hadoop::hdfs::DataTransferEncryptorMessageProto_DataTransferEncryptorStatus_SUCCESS);
+    } else {
+      msg_->set_status(hadoop::hdfs::DataTransferEncryptorMessageProto_DataTransferEncryptorStatus_ERROR);
+    }
+    next(Status::OK());
+  }
+
+ private:
+  DigestMD5Authenticator *authenticator_;
+  BlockReaderOptions *options_;
+  const std::string *request_;
+  hadoop::hdfs::DataTransferEncryptorMessageProto *msg_;
+};
+
+template<class Stream>
+struct DataTransferSaslStream<Stream>::ReadSaslMessageContinuation
+    : continuation::Continuation {
+  ReadSaslMessageContinuation(Stream *stream, std::string *data)
+      : stream_(stream)
+      , data_(data)
+  {}
+
+  virtual void Run(const Next& next) override {
+    read_pb_.reset(
+        new continuation::ReadDelimitedPBMessageContinuation<Stream, 1024>(stream_, &resp_));
+    auto handler = [this,next](const Status &status) {
+      if (status.ok()) {
+        Status new_stat = DataTransferSaslStreamUtil::ConvertToStatus(&resp_, data_);
+        next(new_stat);
+      } else {
+        next(status);
+      }
+    };
+    read_pb_->Run(handler);
+  }
+
+ private:
+  Stream *stream_;
+  std::string *data_;
+  hadoop::hdfs::DataTransferEncryptorMessageProto resp_;
+  std::unique_ptr<continuation::Continuation> read_pb_;
+};
+
+template <class Stream>
+template <class Handler>
+void DataTransferSaslStream<Stream>::Handshake(const Handler &next) {
+  using hadoop::hdfs::DataTransferEncryptorMessageProto;
+  struct State {
+    int magic_number;
+    DataTransferEncryptorMessageProto request0;
+    std::string response0;
+    DataTransferEncryptorMessageProto request1;
+    std::string response1;
+    std::shared_ptr<Stream> stream;
+  };
+  auto s = std::make_shared<State>();
+  s->stream = stream_;
+  s->magic_number = htonl(kDataTransferSasl);
+  DataTransferSaslStreamUtil::PrepareInitialHandshake(&s->request0);
+
+  auto prog = continuation::Write(stream_, asio::buffer(reinterpret_cast<const char*>(&s->magic_number), sizeof(s->magic_number)))
+          >>= WriteDelimitedPBMessage(stream_.get(), &s->request0)
+          >>= ReadSaslMessageContinuation(stream_.get(), &s->response0)
+          >>= AuthenticatorContinuation(&authenticator_, &options_, &s->response0, &s->request1)
+          >>= WriteDelimitedPBMessage(stream_.get(), &s->request1)
+          >>= ReadSaslMessageContinuation(stream_.get(), &s->response1);
+
+  // TODO: Check whether the server and the client matches the QOP
+
+  auto m = std::shared_ptr<decltype(prog)>(new decltype(prog)(std::move(prog)));
+  m->Run([m,s,next](const Status &status) {
+      next(status);
+    });
+}
+
+}
+
+#endif

--- a/src/main/native/lib/common/hdfs.cc
+++ b/src/main/native/lib/common/hdfs.cc
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wrapper.h"
+
+namespace hdfs {
+
+IoService::~IoService() {}
+
+IoService *IoService::New() {
+  return new IoServiceImpl();
+}
+
+}

--- a/src/main/native/lib/common/sasl_authenticator.h
+++ b/src/main/native/lib/common/sasl_authenticator.h
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef COMMON_SASL_AUTHENTICATOR_H_
+#define COMMON_SASL_AUTHENTICATOR_H_
+
+#include "libhdfs++/status.h"
+
+namespace hdfs {
+
+class DigestMD5AuthenticatorTest_TestResponse_Test;
+
+/**
+ * A specialized implementation of RFC 2831 for the HDFS
+ * DataTransferProtocol.
+ *
+ * The current lacks the following features:
+ *   * Encoding the username, realm, and password in ISO-8859-1 when
+ * it is required by the RFC. They are always encoded in UTF-8.
+ *   * Checking whether the challenges from the server are
+ * well-formed.
+ *   * Specifying authzid, digest-uri and maximum buffer size.
+ *   * Supporting QOP other than the auth level.
+ **/
+class DigestMD5Authenticator {
+ public:
+  Status EvaluateResponse(const std::string &payload, std::string *result);
+  DigestMD5Authenticator(const std::string &username, const std::string &password,
+                         bool mock_nonce = false);
+
+ private:
+  Status GenerateFirstResponse(std::string *result);
+  Status GenerateResponseValue(std::string *response_value);
+  Status ParseFirstChallenge(const std::string &payload);
+
+  static size_t NextToken(const std::string &payload, size_t off, std::string *tok);
+  void GenerateCNonce();
+  std::string username_;
+  std::string password_;
+  std::string nonce_;
+  std::string cnonce_;
+  std::string realm_;
+  std::string qop_;
+  unsigned nonce_count_;
+
+  const bool TEST_mock_cnonce_;
+  friend class DigestMD5AuthenticatorTest_TestResponse_Test;
+};
+
+}
+
+#endif

--- a/src/main/native/lib/common/sasl_digest_md5.cc
+++ b/src/main/native/lib/common/sasl_digest_md5.cc
@@ -1,0 +1,239 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sasl_authenticator.h"
+
+#include "common/util.h"
+
+#include <openssl/rand.h>
+#include <openssl/md5.h>
+
+#include <iomanip>
+#include <map>
+#include <sstream>
+
+namespace hdfs {
+
+static std::string QuoteString(const std::string &src);
+static std::string GetMD5Digest(const std::string &src);
+static std::string BinaryToHex(const std::string &src);
+
+static const char kDigestUri[] = "hdfs/0";
+static const size_t kMaxBufferSize = 65536;
+
+DigestMD5Authenticator::DigestMD5Authenticator(const std::string &username, const std::string &password, bool mock_nonce)
+    : username_(username)
+    , password_(password)
+    , nonce_count_(0)
+    , TEST_mock_cnonce_(mock_nonce)
+{}
+
+Status DigestMD5Authenticator::EvaluateResponse(const std::string &payload, std::string *result) {
+  Status status = ParseFirstChallenge(payload);
+  if (status.ok()) {
+    status = GenerateFirstResponse(result);
+  }
+  return status;
+  return Status::Error("");
+}
+
+size_t DigestMD5Authenticator::NextToken(const std::string &payload, size_t off, std::string *tok) {
+  tok->clear();
+  if (off >= payload.size()) {
+    return std::string::npos;
+  }
+
+  char c = payload[off];
+  if (c == '=' || c == ',') {
+    *tok = c;
+    return off + 1;
+  }
+
+  int quote_count = 0;
+  for (; off < payload.size(); ++off) {
+    char c = payload[off];
+    if (c == '"') {
+      ++quote_count;
+      if (quote_count == 2) {
+        return off + 1;
+      }
+      continue;
+    }
+
+    if (c == '=') {
+      if (quote_count) {
+        tok->append(&c, 1);
+      } else {
+        break;
+      }
+    } else if (('0' <= c && c <= '9') || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
+        || c == '+' || c == '/' || c == '-' || c == '_' || c == '@') {
+      tok->append(&c, 1);
+    } else {
+      break;
+    }
+  }
+  return off;
+}
+
+void DigestMD5Authenticator::GenerateCNonce() {
+  if (!TEST_mock_cnonce_) {
+    char buf[8];
+    RAND_pseudo_bytes(reinterpret_cast<unsigned char*>(buf), sizeof(buf));
+    cnonce_ = Base64Encode(std::string(buf, sizeof(buf)));
+  }
+}
+
+Status DigestMD5Authenticator::ParseFirstChallenge(const std::string &payload) {
+  std::map<std::string, std::string> props;
+  std::string token;
+  enum {
+    kStateLVal,
+    kStateEqual,
+    kStateRVal,
+    kStateCommaOrEnd,
+  };
+
+  int state = kStateLVal;
+
+  std::string lval, rval;
+  size_t off = 0;
+  while (true) {
+    off = NextToken(payload, off, &token);
+    if (off == std::string::npos) {
+      break;
+    }
+
+    switch (state) {
+      case kStateLVal:
+        lval = token;
+        state = kStateEqual;
+        break;
+      case kStateEqual:
+        state = kStateRVal;
+        break;
+      case kStateRVal:
+        rval = token;
+        props[lval] = rval;
+        state = kStateCommaOrEnd;
+        break;
+      case kStateCommaOrEnd:
+        state = kStateLVal;
+        break;
+    }
+  }
+
+  if (props["algorithm"] != "md5-sess"
+      || props["charset"] != "utf-8"
+      || props.find("nonce") == props.end()) {
+    return Status::Error("Invalid challenge");
+  }
+  realm_ = props["realm"];
+  nonce_ = props["nonce"];
+  qop_ = props["qop"];
+  return Status::OK();
+}
+
+Status DigestMD5Authenticator::GenerateFirstResponse(std::string *result) {
+  // TODO: Support auth-int and auth-conf
+  // Handle cipher
+  if (qop_ != "auth") {
+    return Status::Unimplemented();
+  }
+
+  std::stringstream ss;
+  GenerateCNonce();
+  ss << "charset=utf-8,username=\"" << QuoteString(username_) << "\""
+     << ",authzid=\"" << QuoteString(username_) << "\""
+     << ",nonce=\"" << QuoteString(nonce_) << "\""
+     << ",digest-uri=\"" << kDigestUri << "\""
+     << ",maxbuf=" << kMaxBufferSize
+     << ",cnonce=\"" << cnonce_ << "\"";
+
+  if (realm_.size()) {
+    ss << ",realm=\"" << QuoteString(realm_) << "\"";
+  }
+
+  ss << ",nc=" << std::hex << std::setw(8) << std::setfill('0') << ++nonce_count_;
+  std::string response_value;
+  GenerateResponseValue(&response_value);
+  ss << ",response=" << response_value;
+  *result = ss.str();
+  return result->size() > 4096 ? Status::Error("Response too big") : Status::OK();
+}
+
+/**
+ * Generate the response value specified in S 2.1.2.1 in RFC2831.
+ **/
+Status DigestMD5Authenticator::GenerateResponseValue(std::string *response_value) {
+  std::stringstream begin_a1, a1_ss;
+  std::string a1, a2;
+
+  if (qop_ == "auth") {
+    a2 = std::string("AUTHENTICATE:") + kDigestUri;
+  } else {
+    a2 = std::string("AUTHENTICATE:") + kDigestUri + ":00000000000000000000000000000000";
+  }
+
+  begin_a1 << username_ << ":" << realm_ << ":" << password_;
+  a1_ss << GetMD5Digest(begin_a1.str()) << ":" << nonce_
+        << ":" << cnonce_ << ":" << username_;
+
+  std::stringstream combine_ss;
+  combine_ss << BinaryToHex(GetMD5Digest(a1_ss.str()))
+             << ":" << nonce_
+             << ":" << std::hex << std::setw(8) << std::setfill('0') << nonce_count_
+             << ":" << cnonce_ << ":" << qop_
+             << ":" << BinaryToHex(GetMD5Digest(a2));
+  *response_value = BinaryToHex(GetMD5Digest(combine_ss.str()));
+  return Status::OK();
+}
+
+static std::string QuoteString(const std::string &src) {
+  std::string dst;
+  dst.resize(2 * src.size());
+  size_t j = 0;
+  for (size_t i = 0; i < src.size(); ++i) {
+    if (src[i] == '"') {
+      dst[j++] = '\\';
+    }
+    dst[j++] = src[i];
+  }
+  dst.resize(j);
+  return dst;
+}
+
+static std::string GetMD5Digest(const std::string &src) {
+  MD5_CTX ctx;
+  unsigned long long res[2];
+  MD5_Init(&ctx);
+  MD5_Update(&ctx, src.c_str(), src.size());
+  MD5_Final(reinterpret_cast<unsigned char*>(res), &ctx);
+  return std::string(reinterpret_cast<char*>(res), sizeof(res));
+}
+
+static std::string BinaryToHex(const std::string &src) {
+  std::stringstream ss;
+  ss << std::hex << std::setfill('0');
+  for (size_t i = 0; i < src.size(); ++i) {
+    unsigned c = (unsigned)(static_cast<unsigned char>(src[i]));
+    ss << std::setw(2) << c;
+  }
+  return ss.str();
+}
+
+}

--- a/src/main/native/lib/common/sasl_digest_md5_test.cc
+++ b/src/main/native/lib/common/sasl_digest_md5_test.cc
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sasl_authenticator.h"
+
+#include <gtest/gtest.h>
+
+namespace hdfs {
+
+/**
+ * Testing whether the authenticator generates the MD5 digest correctly.
+ **/
+TEST(DigestMD5AuthenticatorTest, TestResponse) {
+  const std::string username = "igFLnEx4OIx5PZWHAAAABGhtYWkAAAAoQlAtMTM3MDQ2OTkzLTE5Mi4xNjguMS4yMjctMTQyNDIyMDM4MTM2M4xAAAABAQRSRUFE";
+  const std::string password = "K5IFUibAynVVrApeCXLrBk9Sro8=";
+  DigestMD5Authenticator auth(username, password, true);
+  auth.cnonce_ = "KQlJwBDTseCHpAkFLZls4WcAktp6r5wTzje5feLY";
+  std::string result;
+  Status status = auth.EvaluateResponse("realm=\"0\",nonce=\"+GAWc+O6yEAWpew/qKah8qh4QZLoOLCDcTtEKhlS\",qop=\"auth\",charset=utf-8,algorithm=md5-sess", &result);
+  ASSERT_TRUE(status.ok());
+  ASSERT_TRUE(result.find("response=3a286c2c385b92a06ebc66d58b8c4330") != std::string::npos);
+}
+
+}

--- a/src/main/native/lib/common/status.cc
+++ b/src/main/native/lib/common/status.cc
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "libhdfs++/status.h"
+
+#include <cassert>
+#include <cstring>
+
+namespace hdfs {
+
+Status::Status(int code, const char *msg1)
+    : state_(ConstructState(code, msg1, nullptr))
+{}
+
+Status::Status(int code, const char *msg1, const char *msg2)
+    : state_(ConstructState(code, msg1, msg2))
+{}
+
+const char *Status::ConstructState(int code, const char *msg1, const char *msg2) {
+  assert(code != kOk);
+  const uint32_t len1 = strlen(msg1);
+  const uint32_t len2 = msg2 ? strlen(msg2) : 0;
+  const uint32_t size = len1 + (len2 ? (2 + len2) : 0);
+  char* result = new char[size + 8 + 2];
+  *reinterpret_cast<uint32_t*>(result) = size;
+  *reinterpret_cast<uint32_t*>(result + 4) = code;
+  memcpy(result + 8, msg1, len1);
+  if (len2) {
+    result[8 + len1] = ':';
+    result[9 + len1] = ' ';
+    memcpy(result + 10 + len1, msg2, len2);
+  }
+  return result;
+}
+
+std::string Status::ToString() const {
+  if (!state_) {
+    return "OK";
+  } else {
+    uint32_t length = *reinterpret_cast<const uint32_t*>(state_);
+    return std::string(state_ + 8, length);
+  }
+}
+
+const char* Status::CopyState(const char* state) {
+  uint32_t size;
+  memcpy(&size, state, sizeof(size));
+  char* result = new char[size + 8];
+  memcpy(result, state, size + 8);
+  return result;
+}
+
+}

--- a/src/main/native/lib/common/util.h
+++ b/src/main/native/lib/common/util.h
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LIB_COMMON_UTIL_H_
+#define LIB_COMMON_UTIL_H_
+
+#include "libhdfs++/status.h"
+
+#include <asio/error_code.hpp>
+
+#include <google/protobuf/message_lite.h>
+#include <google/protobuf/io/coded_stream.h>
+
+namespace hdfs {
+
+static inline Status ToStatus(const ::asio::error_code &ec) {
+  if (ec) {
+    return Status(ec.value(), ec.message().c_str());
+  } else {
+    return Status::OK();
+  }
+}
+
+static inline int DelimitedPBMessageSize(
+    const ::google::protobuf::MessageLite *msg) {
+  size_t size = msg->ByteSize();
+  return ::google::protobuf::io::CodedOutputStream::VarintSize32(size) + size;
+}
+
+static inline void ReadDelimitedPBMessage(
+    ::google::protobuf::io::CodedInputStream *in,
+    ::google::protobuf::MessageLite *msg) {
+  uint32_t size = 0;
+  in->ReadVarint32(&size);
+  auto limit = in->PushLimit(size);
+  msg->ParseFromCodedStream(in);
+  in->PopLimit(limit);
+}
+
+std::string Base64Encode(const std::string &src);
+
+}
+
+#endif

--- a/src/main/native/lib/common/wrapper.h
+++ b/src/main/native/lib/common/wrapper.h
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef COMMON_WRAPPER_H_
+#define COMMON_WRAPPER_H_
+
+#include "libhdfs++/hdfs.h"
+
+#include <asio/io_service.hpp>
+
+namespace hdfs {
+
+class IoServiceImpl : public IoService {
+ public:
+  virtual void Run() override {
+    asio::io_service::work work(io_service_);
+    io_service_.run();
+  }
+  virtual void Stop() override { io_service_.stop(); }
+  ::asio::io_service &io_service() { return io_service_; }
+ private:
+  ::asio::io_service io_service_;
+};
+
+}
+
+#endif

--- a/src/main/native/lib/fs/CMakeLists.txt
+++ b/src/main/native/lib/fs/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(fs filesystem.cc inputstream.cc)
+add_executable(inputstream_test inputstream_test.cc)
+target_link_libraries(inputstream_test fs rpc reader common proto ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})

--- a/src/main/native/lib/fs/CMakeLists.txt
+++ b/src/main/native/lib/fs/CMakeLists.txt
@@ -1,3 +1,5 @@
-add_library(fs filesystem.cc inputstream.cc)
+add_library(fs filesystem.cc inputstream.cc chdfs.cc)
 add_executable(inputstream_test inputstream_test.cc)
+add_executable(cinputstream_test cinputstream_test.cc)
 target_link_libraries(inputstream_test fs rpc reader common proto ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(cinputstream_test fs rpc reader common proto ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})

--- a/src/main/native/lib/fs/CMakeLists.txt
+++ b/src/main/native/lib/fs/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(fs filesystem.cc inputstream.cc chdfs.cc)
 add_executable(inputstream_test inputstream_test.cc)
 add_executable(cinputstream_test cinputstream_test.cc)
+add_executable(perf_tests perf_tests.cc)
 target_link_libraries(inputstream_test fs rpc reader common proto ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 target_link_libraries(cinputstream_test fs rpc reader common proto ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(perf_tests fs rpc reader common proto ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})

--- a/src/main/native/lib/fs/chdfs.cc
+++ b/src/main/native/lib/fs/chdfs.cc
@@ -1,0 +1,199 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//Expose a pure C interface that doesn't need any C++/C++11 header files
+//todo: 
+//  Need to be able to pass in parameters to hint at resource allocation like how many threads call run on io_service
+//  It would be nice to be able to pass in counters to gather statistics for filesystem operations
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <pthread.h>
+
+#include "libhdfs++/chdfs.h"
+#include "libhdfs++/hdfs.h"
+
+#include <iostream>
+#include <string>
+#include <thread>
+
+//undefine these and requests will lock up
+#define CHDFS_SERIALIZED_OPEN
+//#define CHDFS_SERIALIZED_READ
+
+//---------------------------------------------------------------------------------------
+//  Wrap C++ calls in C
+//---------------------------------------------------------------------------------------
+
+using namespace hdfs;
+
+
+//todo: switch back to std::thread
+void *call_run(void *servicePtr) {
+  IoService *wrappedService = reinterpret_cast<IoService*>(servicePtr);
+  wrappedService->Run();
+  return NULL;
+}
+
+//Copied almost directly from inputstream_test.  Replaced std::thread with pthreads temporarily
+class Executor {
+public:
+  Executor() {
+    //Create a new IoService object. This wraps the boost io_service object.
+    io_service_ = std::unique_ptr<IoService>(IoService::New());
+    //Call run on IoService object in a background thread, the run call should never return.
+    int ret = pthread_create(&processing_thread, NULL, call_run, reinterpret_cast<void*>(io_service_.get()));
+    
+    if(ret != 0) {
+      //strip out exceptions later
+      throw std::runtime_error("unable to start pthread?");
+    }
+  }
+
+  ~Executor() {
+    //Stop IoService event loop and background thread.  Don't need this yet.
+  }
+ 
+  IoService *io_service() {
+    return io_service_.get();
+  }
+
+  std::unique_ptr<IoService> io_service_;
+  pthread_t processing_thread;  
+};
+
+
+struct hdfsFile_struct {
+  hdfsFile_struct() : inputStream(NULL) {};
+  hdfsFile_struct(InputStream *is) : inputStream(is) {};
+
+  virtual ~hdfsFile_struct() {
+    if(NULL != inputStream)
+      delete inputStream;
+  }
+
+  InputStream *inputStream;
+};
+
+
+struct hdfsFS_struct {
+  hdfsFS_struct() : fileSystem(NULL), backgroundIoService(NULL) {};
+  hdfsFS_struct(FileSystem *fs, Executor *ex) : fileSystem(fs), backgroundIoService(ex) {};
+  virtual ~hdfsFS_struct() {
+    delete fileSystem;
+    delete backgroundIoService;
+  };
+ 
+  FileSystem *fileSystem;
+  Executor *backgroundIoService;
+};
+
+
+/*  FS initialization routine
+ *    -need to start background thread(s) to run asio::io_service
+ *    -connect to specified namenode host:port
+ *    -this will need to be extended to allow application to control memory management routines
+ *     by passing an allocator/deleter pair as well as specify io_service thread count 
+ */
+hdfsFS hdfsConnect(const char *nnhost, unsigned short nnport) {
+  std::unique_ptr<Executor> background_io_service = std::unique_ptr<Executor>(new Executor());
+
+  if(NULL == background_io_service) 
+    return NULL;
+
+  //connect to NN, fileSystem will be set on success
+  FileSystem *fileSystem = NULL;
+  Status stat = FileSystem::New(background_io_service->io_service(), nnhost, nnport, &fileSystem);
+  if(!stat.ok())
+    return NULL;
+
+  //make a hdfsFS handle
+  return new hdfsFS_struct(fileSystem, background_io_service.release());
+}
+
+
+int hdfsDisconnect(hdfsFS fs) {
+  //likely other stuff to free up, just stub for short tests
+  if(NULL != fs)
+    delete fs;  
+  else
+    return -1;
+  return 0;
+}
+
+#ifdef CHDFS_SERIALIZED_OPEN
+  pthread_mutex_t open_lock = PTHREAD_MUTEX_INITIALIZER;
+#endif
+hdfsFile hdfsOpenFile(hdfsFS fs, const char *path, int flags, int bufferSize, short replication, int blockSize) {
+  #ifdef CHDFS_SERIALIZED_OPEN
+    pthread_mutex_lock(&open_lock);
+  #endif
+  //the following four params are just placeholders until write path is finished
+  (void)flags;
+  (void)bufferSize;
+  (void)replication;
+  (void)blockSize;
+
+  //assuming we want to do a read with default settings, sufficient for now
+  InputStream *isPtr = NULL;
+  Status stat = fs->fileSystem->Open(path, &isPtr);
+  if(!stat.ok())
+    return NULL;
+
+  #ifdef CHDFS_SERIALIZED_OPEN
+    pthread_mutex_unlock(&open_lock);
+  #endif
+  return new hdfsFile_struct(isPtr);
+}
+
+
+int hdfsCloseFile(hdfsFS fs, hdfsFile file) {
+  (void)fs;
+  if(NULL != file)
+    delete file;
+  else
+    return -1;
+  return 0;
+}
+
+#ifdef CHDFS_SERIALIZED_READ
+  pthread_mutex_t read_lock = PTHREAD_MUTEX_INITIALIZER;
+#endif
+size_t hdfsPread(hdfsFS fs, hdfsFile file, off_t position, void *buf, size_t length) {
+  #ifdef CHDFS_SERIALIZED_READ
+    pthread_mutex_lock(&read_lock);  
+  #endif
+
+  if(NULL == fs || NULL == file)
+    //set errno
+    return 0;   
+
+  size_t readBytes = 0;
+  Status stat = file->inputStream->PositionRead(buf, length, position, &readBytes);
+  if(!stat.ok()) {
+    //set errno
+    return 0;
+  }
+
+  #ifdef CHDFS_SERIALIZED_READ
+    pthread_mutex_unlock(&read_lock);
+  #endif
+  return readBytes;
+}
+
+

--- a/src/main/native/lib/fs/chdfs.cc
+++ b/src/main/native/lib/fs/chdfs.cc
@@ -1,0 +1,205 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//Expose a pure C interface that doesn't need any C++/C++11 header files
+//Avoid use of C++11 in this file as well because it's going to be backported c++98 eventually anyway. eg raw pthreads instead of C++11 threads
+
+//Intended to be compatible with libhdfs(3).  Currently only a subset of operations are supported.
+//  hdfsConnect
+//  hdfsDisconnect
+//  hdfsOpenFile
+//  hdfsCloseFile
+//  hdfsPread
+
+
+//todo: 
+//  Need to be able to pass in parameters to hint at resource allocation like how many threads call run on io_service
+//  Implement real streams that keep track of position on top of inputstream
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <pthread.h>
+
+#include "libhdfs++/chdfs.h"
+#include "libhdfs++/hdfs.h"
+
+#include <iostream>
+#include <string>
+#include <thread>
+
+
+//---------------------------------------------------------------------------------------
+//  Wrap C++ calls in C
+//---------------------------------------------------------------------------------------
+
+using namespace hdfs;
+
+
+void *call_run(void *servicePtr) {
+  IoService *wrappedService = reinterpret_cast<IoService*>(servicePtr);
+  wrappedService->Run();
+  return NULL;
+}
+
+//Copied almost directly from inputstream_test.
+//Eventually add a way for the user to specify how many threads call run on io_service
+class Executor {
+public:
+  Executor() {
+    //Create a new IoService object. This wraps the boost io_service object.
+    io_service_ = std::unique_ptr<IoService>(IoService::New());
+
+    //Call run on IoService object in a background thread, the run call should never return.
+    int ret = pthread_create(&processing_thread, NULL, call_run, reinterpret_cast<void*>(io_service_.get()));
+    
+    if(ret != 0) {
+      //reset io_service ptr to null so caller can check.  Don't want to throw.
+      io_service_ = NULL;
+    }
+  }
+
+  ~Executor() {
+    //Stop IoService event loop and background thread.
+    io_service_->Stop();
+  }
+ 
+  IoService *io_service() {
+    return io_service_.get();
+  }
+
+private:
+  std::unique_ptr<IoService> io_service_;
+  pthread_t processing_thread; 
+ 
+};
+
+
+struct hdfsFile_struct {
+  hdfsFile_struct() : inputStream(NULL) {};
+  hdfsFile_struct(InputStream *is) : inputStream(is) {};
+
+  virtual ~hdfsFile_struct() {
+    if(NULL != inputStream)
+      delete inputStream;
+  }
+
+  InputStream *inputStream;
+};
+
+
+struct hdfsFS_struct {
+  hdfsFS_struct() : fileSystem(NULL), backgroundIoService(NULL) {};
+  hdfsFS_struct(FileSystem *fs, Executor *ex) : fileSystem(fs), backgroundIoService(ex) {};
+  virtual ~hdfsFS_struct() {
+    if(fileSystem) {
+      delete fileSystem;
+    }
+    if(backgroundIoService) {
+      delete backgroundIoService;
+    }
+  };
+ 
+  FileSystem *fileSystem;
+  Executor   *backgroundIoService;
+};
+
+
+/*  FS initialization routine
+ *    -need to start background thread(s) to run asio::io_service
+ *    -connect to specified namenode host:port
+ *    -this will need to be extended to allow application to pass a few things:
+ *      -malloc/delete pair for using specialized pools
+ *      -thread count for background threads
+ */
+hdfsFS hdfsConnect(const char *nnhost, unsigned short nnport) {
+  std::unique_ptr<Executor> background_io_service = std::unique_ptr<Executor>(new Executor());
+
+  if(NULL == background_io_service) 
+    return NULL;
+
+  //connect to NN, fileSystem will be set on success
+  FileSystem *fileSystem = NULL;
+  Status stat = FileSystem::New(background_io_service->io_service(), nnhost, nnport, &fileSystem);
+  if(!stat.ok())
+    return NULL;
+
+  //make a hdfsFS handle
+  return new hdfsFS_struct(fileSystem, background_io_service.release());
+}
+
+
+int hdfsDisconnect(hdfsFS fs) {
+  //delete fs if it exists, fs dtor shall clean up everything it owns
+  if(NULL != fs)
+    delete fs;  
+  else
+    return -1;
+  return 0;
+}
+
+
+//todo: Only the rpc layer isn't thread safe.  Push mutex down to critical areas in RPC so we can push
+//multiple requests over the wire.
+pthread_mutex_t open_lock = PTHREAD_MUTEX_INITIALIZER;
+hdfsFile hdfsOpenFile(hdfsFS fs, const char *path, int flags, int bufferSize, short replication, int blockSize) {
+  pthread_mutex_lock(&open_lock);
+
+  //The following four params are just placeholders until write path is finished, add void so compiler doesn't complain.
+  (void)flags;
+  (void)bufferSize;
+  (void)replication;
+  (void)blockSize;
+
+  //assuming we want to do a read with default settings, sufficient for now
+  InputStream *isPtr = NULL;
+  Status stat = fs->fileSystem->Open(path, &isPtr);
+  if(!stat.ok())
+    return NULL;
+
+  //may need to switch to scoped lock if anything in here can throw.
+  pthread_mutex_unlock(&open_lock);
+  return new hdfsFile_struct(isPtr);
+}
+
+
+int hdfsCloseFile(hdfsFS fs, hdfsFile file) {
+  (void)fs;
+  if(NULL != file)
+    delete file;
+  else
+    return -1;
+  return 0;
+}
+
+size_t hdfsPread(hdfsFS fs, hdfsFile file, off_t position, void *buf, size_t length) {
+  if(NULL == fs || NULL == file) {
+    //possibly set errno here
+    return 0;   
+  }
+
+  size_t readBytes = 0;
+  Status stat = file->inputStream->PositionRead(buf, length, position, &readBytes);
+  if(!stat.ok()) {
+    //possibly set errno here
+    return 0;
+  }
+
+  return readBytes;
+}
+
+

--- a/src/main/native/lib/fs/cinputstream_test.cc
+++ b/src/main/native/lib/fs/cinputstream_test.cc
@@ -1,0 +1,51 @@
+#include "libhdfs++/chdfs.h"
+
+
+#include <string>
+#include <iostream>
+#include <cstring>
+
+//Simple test that can be run through valgrind to make sure the libhdfs compatible API isn't leaking memory.
+
+
+hdfsFS fs = NULL;
+
+int main(int argc, char **argv){
+  if(argc != 4) {
+    std::cout << "usage: ./cinputstream_test <host> <port> <path>" << std::endl;
+    return 1;
+  }
+
+  fs = hdfsConnect(argv[1], std::stoi(argv[2]));
+  if(NULL == fs){
+    std::cout << "error: initializing filesystem returned null" << std::endl;
+    return 1;
+  }
+
+  hdfsFile file = hdfsOpenFile(fs, argv[3], 0, 0, 0, 0);
+  if(file == NULL) {
+    std::cout << "error: could not open file" << std::endl;
+    return 1;
+  }
+
+  char buf[1000];
+  memset(buf, 0, 1000);
+
+  int count = hdfsPread(fs, file, 0 /*pos*/, buf, 50 /*max bytes to read*/);
+  if(count == -1) {
+    std::cout << "error: could not read file" << std::endl;
+    return 1;
+  }
+
+  std::cout << "read " << count << " bytes" << std::endl;
+  std::cout << buf << std::endl;
+  
+
+  hdfsCloseFile(fs, file);
+  hdfsDisconnect(fs);
+
+
+}
+
+
+

--- a/src/main/native/lib/fs/filesystem.cc
+++ b/src/main/native/lib/fs/filesystem.cc
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "filesystem.h"
+
+#include "common/util.h"
+
+#include <asio/ip/tcp.hpp>
+
+#include <limits>
+
+namespace hdfs {
+
+static const char kNamenodeProtocol[] = "org.apache.hadoop.hdfs.protocol.ClientProtocol";
+static const int kNamenodeProtocolVersion = 1;
+
+using ::asio::ip::tcp;
+
+FileSystem::~FileSystem()
+{}
+
+Status FileSystem::New(IoService *io_service, const char *server,
+                       unsigned short port, FileSystem **fsptr) {
+  std::unique_ptr<FileSystemImpl> impl(new FileSystemImpl(io_service));
+  Status stat = impl->Connect(server, port);
+  if (stat.ok()) {
+    *fsptr = impl.release();
+  }
+  return stat;
+}
+
+FileSystemImpl::FileSystemImpl(IoService *io_service)
+    : io_service_(static_cast<IoServiceImpl*>(io_service))
+    , engine_(&io_service_->io_service(), RpcEngine::GetRandomClientName(),
+              kNamenodeProtocol, kNamenodeProtocolVersion)
+    , namenode_(&engine_)
+{}
+
+Status FileSystemImpl::Connect(const char *server, unsigned short port) {
+  asio::error_code ec;
+  tcp::resolver resolver(io_service_->io_service());
+  tcp::resolver::query query(tcp::v4(), server, std::to_string(port));
+  tcp::resolver::iterator iterator = resolver.resolve(query, ec);
+
+  if (ec) {
+    return ToStatus(ec);
+  }
+
+  Status stat = engine_.Connect(*iterator);
+  if (!stat.ok()) {
+    return stat;
+  }
+  engine_.StartReadLoop();
+  return stat;
+}
+
+Status FileSystemImpl::Open(const char *path, InputStream **isptr) {
+  using ::hadoop::hdfs::GetBlockLocationsRequestProto;
+  using ::hadoop::hdfs::GetBlockLocationsResponseProto;
+
+  GetBlockLocationsRequestProto req;
+  auto resp = std::make_shared<GetBlockLocationsResponseProto>();
+  req.set_src(path);
+  req.set_offset(0);
+  req.set_length(std::numeric_limits<long long>::max());
+  Status stat = namenode_.GetBlockLocations(&req, resp);
+  if (!stat.ok()) {
+    return stat;
+  }
+
+  *isptr = new InputStreamImpl(this, &resp->locations());
+  return Status::OK();
+}
+
+}

--- a/src/main/native/lib/fs/filesystem.h
+++ b/src/main/native/lib/fs/filesystem.h
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FS_FILESYSTEM_H_
+#define FS_FILESYSTEM_H_
+
+#include "namenode_protocol.h"
+#include "common/wrapper.h"
+#include "libhdfs++/hdfs.h"
+
+namespace hdfs {
+
+class FileSystemImpl : public FileSystem {
+ public:
+  FileSystemImpl(IoService *io_service);
+  Status Connect(const char *server, unsigned short port);
+  virtual Status Open(const char *path, InputStream **isptr) override;
+  RpcEngine &rpc_engine() { return engine_; }
+ private:
+  IoServiceImpl *io_service_;
+  RpcEngine engine_;
+  ClientNamenodeProtocol namenode_;
+};
+
+class InputStreamImpl : public InputStream {
+ public:
+  InputStreamImpl(FileSystemImpl *fs, const ::hadoop::hdfs::LocatedBlocksProto *blocks);
+  virtual Status PositionRead(void *buf, size_t nbyte, size_t offset, size_t *read_bytes) override;
+  template<class MutableBufferSequence, class Handler>
+  void AsyncPreadSome(size_t offset, const MutableBufferSequence &buffers,
+                      const Handler &handler);
+ private:
+  FileSystemImpl *fs_;
+  unsigned long long file_length_;
+  std::vector<::hadoop::hdfs::LocatedBlockProto> blocks_;
+  struct HandshakeContinuation;
+  template<class MutableBufferSequence>
+  struct ReadBlockContinuation;
+};
+
+}
+
+#include "inputstream_impl.h"
+
+#endif

--- a/src/main/native/lib/fs/inputstream.cc
+++ b/src/main/native/lib/fs/inputstream.cc
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "filesystem.h"
+
+namespace hdfs {
+
+using ::hadoop::hdfs::LocatedBlocksProto;
+
+InputStream::~InputStream()
+{}
+
+InputStreamImpl::InputStreamImpl(FileSystemImpl *fs, const LocatedBlocksProto *blocks)
+    : fs_(fs)
+    , file_length_(blocks->filelength())
+{
+  for (const auto &block : blocks->blocks()) {
+    blocks_.push_back(block);
+  }
+
+  if (blocks->has_lastblock() && blocks->lastblock().b().numbytes()) {
+    blocks_.push_back(blocks->lastblock());
+  }
+}
+
+Status InputStreamImpl::PositionRead(void *buf, size_t nbyte, size_t offset, size_t *read_bytes) {
+  auto stat = std::make_shared<std::promise<Status>>();
+  std::future<Status> future(stat->get_future());
+  auto handler = [stat,read_bytes](const Status &status, size_t transferred) {
+    *read_bytes = transferred;
+    stat->set_value(status);
+  };
+
+  AsyncPreadSome(offset, asio::buffer(buf, nbyte), handler);
+  return future.get();
+}
+
+}

--- a/src/main/native/lib/fs/inputstream_impl.h
+++ b/src/main/native/lib/fs/inputstream_impl.h
@@ -1,0 +1,160 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FS_INPUTSTREAM_IMPL_H_
+#define FS_INPUTSTREAM_IMPL_H_
+
+#include "reader/block_reader.h"
+
+#include "common/continuation/asio.h"
+#include "common/continuation/protobuf.h"
+
+#include <functional>
+#include <future>
+
+namespace hdfs {
+
+struct InputStreamImpl::HandshakeContinuation : continuation::Continuation {
+  typedef RemoteBlockReader<::asio::ip::tcp::socket> Reader;
+  HandshakeContinuation(Reader *reader, const std::string &client_name,
+               const hadoop::common::TokenProto *token,
+               const hadoop::hdfs::ExtendedBlockProto *block,
+               uint64_t length, uint64_t offset)
+      : reader_(reader)
+      , client_name_(client_name)
+      , length_(length)
+      , offset_(offset)
+  {
+    if (token) {
+      token_.reset(new hadoop::common::TokenProto());
+      token_->CheckTypeAndMergeFrom(*token);
+    }
+    block_.CheckTypeAndMergeFrom(*block);
+  }
+
+  virtual void Run(const Next& next) override {
+    reader_->async_connect(client_name_, token_.get(), &block_, length_, offset_, next);
+  }
+
+ private:
+  Reader *reader_;
+  const std::string client_name_;
+  std::unique_ptr<hadoop::common::TokenProto> token_;
+  hadoop::hdfs::ExtendedBlockProto block_;
+  uint64_t length_;
+  uint64_t offset_;
+};
+
+template<class MutableBufferSequence>
+struct InputStreamImpl::ReadBlockContinuation : continuation::Continuation {
+  typedef RemoteBlockReader<::asio::ip::tcp::socket> Reader;
+  ReadBlockContinuation(Reader *reader, MutableBufferSequence buffer,
+                 size_t *transferred)
+      : reader_(reader)
+      , buffer_(buffer)
+      , buffer_size_(asio::buffer_size(buffer))
+      , transferred_(transferred)
+  {}
+
+  virtual void Run(const Next& next) override {
+    *transferred_ = 0;
+    next_ = next;
+    OnReadData(Status::OK(), 0);
+  }
+
+ private:
+  Reader *reader_;
+  MutableBufferSequence buffer_;
+  const size_t buffer_size_;
+  size_t *transferred_;
+  std::function<void(const Status &)> next_;
+
+  void OnReadData(const Status &status, size_t transferred) {
+    using std::placeholders::_1;
+    using std::placeholders::_2;
+    *transferred_ += transferred;
+    if (!status.ok()) {
+      next_(status);
+    } else if (*transferred_ >= buffer_size_) {
+      next_(status);
+    } else {
+      reader_->async_read_some(
+          asio::buffer(buffer_ + *transferred_, buffer_size_ - *transferred_),
+          std::bind(&ReadBlockContinuation::OnReadData, this, _1, _2));
+    }
+  }
+};
+
+
+template<class MutableBufferSequence, class Handler>
+void InputStreamImpl::AsyncPreadSome(
+    size_t offset, const MutableBufferSequence &buffers,
+    const Handler &handler) {
+  using ::hadoop::hdfs::LocatedBlockProto;
+  namespace ip = ::asio::ip;
+  using ::asio::ip::tcp;
+
+  auto it = std::find_if(
+      blocks_.begin(), blocks_.end(),
+      [offset](const LocatedBlockProto &p) {
+        return p.offset() <= offset && offset < p.offset() + p.b().numbytes();
+      });
+
+  if (it == blocks_.end()) {
+    handler(Status::InvalidArgument("Cannot find corresponding blocks"), 0);
+    return;
+  } else if (!it->locs_size()) {
+    handler(Status::ResourceUnavailable("No datanodes available"), 0);
+    return;
+  }
+
+  uint64_t offset_within_block = offset - it->offset();
+  uint64_t size_within_block =
+      std::min<uint64_t>(it->b().numbytes() - offset_within_block, asio::buffer_size(buffers));
+
+  struct State {
+    std::unique_ptr<tcp::socket> conn;
+    std::shared_ptr<RemoteBlockReader<tcp::socket> > reader;
+    LocatedBlockProto block;
+    std::vector<tcp::endpoint> endpoints;
+    size_t transferred;
+  };
+
+  auto m = continuation::Pipeline<State>::Create();
+  auto &s = m->state();
+  s.conn.reset(new tcp::socket(fs_->rpc_engine().io_service()));
+  s.reader = std::make_shared<RemoteBlockReader<tcp::socket> >(BlockReaderOptions(), s.conn.get());
+  s.block = *it;
+  for (auto &loc : it->locs()) {
+    auto datanode = loc.id();
+    s.endpoints.push_back(tcp::endpoint(ip::address::from_string(datanode.ipaddr()), datanode.xferport()));
+  }
+
+  m->Push(continuation::Connect(s.conn.get(), s.endpoints.begin(), s.endpoints.end()))
+      .Push(new HandshakeContinuation(s.reader.get(), fs_->rpc_engine().client_name(), nullptr,
+                                   &s.block.b(), size_within_block, offset_within_block))
+      .Push(new ReadBlockContinuation<::asio::mutable_buffers_1>(
+          s.reader.get(), asio::buffer(buffers, size_within_block), &s.transferred));
+
+  m->Run([handler](const Status &status, const State &state) {
+      handler(status, state.transferred);
+    });
+}
+
+}
+
+#endif

--- a/src/main/native/lib/fs/inputstream_test.cc
+++ b/src/main/native/lib/fs/inputstream_test.cc
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "libhdfs++/hdfs.h"
+
+#include <iostream>
+#include <string>
+#include <thread>
+
+using namespace hdfs;
+
+class Executor {
+ public:
+  Executor()
+      : io_service_(IoService::New())
+      , thread_(std::bind(&IoService::Run, io_service_.get()))
+  {}
+
+  IoService *io_service() { return io_service_.get(); }
+
+  ~Executor() {
+    io_service_->Stop();
+    thread_.join();
+  }
+
+  std::unique_ptr<IoService> io_service_;
+  std::thread thread_;
+};
+
+int main(int argc, char *argv[]) {
+  if (argc != 4) {
+    std::cerr
+        << "Print files stored in a HDFS cluster.\n"
+        << "Usage: " << argv[0] << " "
+        << "<nnhost> <nnport> <file>\n";
+    return 1;
+  }
+
+  Executor executor;
+
+  FileSystem *fsptr;
+  Status stat = FileSystem::New(executor.io_service(), argv[1], std::stoi(argv[2]), &fsptr);
+  if (!stat.ok()) {
+    std::cerr << "Cannot create the filesystem: " << stat.ToString() << std::endl;
+    return 1;
+  }
+
+  std::unique_ptr<FileSystem> fs(fsptr);
+
+  InputStream *isptr;
+  stat = fs->Open(argv[3], &isptr);
+  if (!stat.ok()) {
+    std::cerr << "Cannot open the file: " << stat.ToString() << std::endl;
+    return 1;
+  }
+
+  std::unique_ptr<InputStream> is(isptr);
+
+  char buf[8192] = {0,};
+  size_t read_bytes = 0;
+  stat = is->PositionRead(buf, sizeof(buf), 0, &read_bytes);
+  if (!stat.ok()) {
+    std::cerr << "Read failures: " << stat.ToString() << std::endl;
+  }
+  std::cerr << "Read bytes:" << read_bytes << std::endl << buf << std::endl;
+  return 0;
+}

--- a/src/main/native/lib/fs/namenode_protocol.h
+++ b/src/main/native/lib/fs/namenode_protocol.h
@@ -15,36 +15,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef LIBHDFSPP_HDFS_H_
-#define LIBHDFSPP_HDFS_H_
+#ifndef FS_NAMENODE_PROTOCOL_H_
+#define FS_NAMENODE_PROTOCOL_H_
 
-#include "libhdfs++/status.h"
+#include "ClientNamenodeProtocol.pb.h"
+#include "rpc/rpc_engine.h"
 
 namespace hdfs {
 
-class IoService {
+class ClientNamenodeProtocol {
  public:
-  static IoService *New();
-  virtual void Run() = 0;
-  virtual void Stop() = 0;
-  virtual ~IoService();
+  ClientNamenodeProtocol(RpcEngine *engine)
+      : engine_(engine)
+  {}
+
+  Status GetBlockLocations(const ::hadoop::hdfs::GetBlockLocationsRequestProto *request,
+                           std::shared_ptr<::hadoop::hdfs::GetBlockLocationsResponseProto> response) {
+    return engine_->Rpc("getBlockLocations", request, response);
+  }
+ private:
+  RpcEngine *engine_;
 };
 
-
-class InputStream {
- public:
-  virtual Status PositionRead(void *buf, size_t nbyte, size_t offset, size_t *read_bytes) = 0;
-  virtual ~InputStream();
 };
-
-class FileSystem {
- public:
-  static Status New(IoService *io_service, const char *server,
-                    unsigned short port, FileSystem **fsptr);
-  virtual Status Open(const char *path, InputStream **isptr) = 0;
-  virtual ~FileSystem();
-};
-
-}
 
 #endif

--- a/src/main/native/lib/fs/perf_tests.cc
+++ b/src/main/native/lib/fs/perf_tests.cc
@@ -1,0 +1,281 @@
+#include "libhdfs++/chdfs.h"
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <chrono>
+#include <random>
+#include <thread>
+
+
+/*
+    Basic perfomance/stress tests for libhdfs++.  
+    Currently gets the job done but things to do are:
+        -#threads should be cmd line parameter
+        -#seeks, read sizes, etc should be command line parameters
+        -aggragate thread statistics, print nicer output
+*/
+
+const int scan_thread_count = 8;
+const int seek_thread_count = 8;
+
+//default to reading 1MB blocks for linear scans
+static const size_t KB = 1024;
+static const size_t MB = 1024 * 1024;
+
+
+struct seek_info {
+  seek_info() : seek_count(0), fail_count(0), runtime(0) {};
+  std::string str() {
+    std::stringstream ss;
+    ss << "seeks: " << seek_count << " failed reads:" << fail_count << " runtime:" << runtime << " seeks/sec:" << (seek_count+fail_count)/runtime;
+    return ss.str();
+  }
+
+  int seek_count;
+  int fail_count;
+  double runtime;
+};
+
+struct scan_info {
+  scan_info() : read_bytes(0), runtime(0.0) {};
+  std::string str() {
+    std::stringstream ss;
+    ss << "read " << read_bytes << "bytes in " << runtime << " seconds, bandwidth " << read_bytes / runtime / MB << "MB/s";
+    return ss.str();
+  }
+
+  uint64_t read_bytes;
+  double runtime;
+};
+
+
+seek_info single_threaded_random_seek(hdfsFS fs, hdfsFile file, 
+                                      unsigned int count = 1000,   //how many seeks to try
+                                      off_t window_min = 0,        //minimum offset into file
+                                      off_t window_max = 32 * MB); //max offset into file
+
+scan_info single_threaded_linear_scan(hdfsFS fs, hdfsFile file,
+                                      size_t read_size = 128 * KB,
+                                      off_t start = 0,      //where in file to start reading
+                                      off_t end = 64 * MB); //byte offset in file to stop reading
+
+void n_threaded_linear_scan(hdfsFS fs, std::string path, int threadcount, 
+                                size_t read_size = 128 * KB,
+                                off_t start = 0,
+                                off_t end = 64 * MB); 
+
+void n_threaded_random_seek(hdfsFS fs, std::string path, int threadcount,
+                                unsigned int count = 1000,
+                                off_t window_min = 0,
+                                off_t window_max = 32 * MB);
+
+
+
+
+int main(int argc, char **argv) {
+  if(argc != 5) {
+    std::cout << "usage: ./perf_tests <host> <port> <file> [-threaded_read, -threaded_seek]" << std::endl;
+    return 1;
+  }
+  
+  std::string cmd(argv[4]);
+  hdfsFS fs = hdfsConnect(argv[1], std::atoi(argv[2]));   
+
+
+  if(cmd == "-threaded_read") {
+    n_threaded_linear_scan(fs, argv[3], scan_thread_count, 128*KB, 0, 32*MB);
+  } else if (cmd == "-threaded_seek") {
+    n_threaded_random_seek(fs, argv[3], seek_thread_count, 10000, 0, 32 * MB);
+  } else {
+    std::cerr << "command " << cmd << " not recognized" << std::endl;
+  }
+
+  hdfsDisconnect(fs);
+
+  return 0;
+}
+
+
+seek_info single_threaded_random_seek(hdfsFS fs, hdfsFile file, unsigned int count, off_t window_min, off_t window_max){
+  seek_info info;
+
+  //rng setup, bound by window size
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dis(window_min, window_max);
+
+  std::chrono::time_point<std::chrono::system_clock> start, end;
+  start = std::chrono::system_clock::now();
+
+  for(unsigned int i=0;i<count;i++){
+    std::uint64_t idx = dis(gen);
+    char buf[1];
+    std::int64_t cnt = hdfsPread(fs, file, idx, buf, 1);
+    if(cnt != 1) {
+      info.fail_count++;
+    } else {
+      info.seek_count++;
+    }
+  }
+
+  end = std::chrono::system_clock::now();
+  std::chrono::duration<double> elapsed = end - start;
+  info.runtime = elapsed.count();
+
+  return info;
+}
+
+
+
+scan_info single_threaded_linear_scan(hdfsFS fs, hdfsFile file, size_t buffsize, off_t start_offset, off_t end_offset) {
+  scan_info info;
+
+  std::vector<char> buffer;
+  buffer.reserve(buffsize);
+
+  std::chrono::time_point<std::chrono::system_clock> start, end;
+  start = std::chrono::system_clock::now();  
+
+  std::int64_t count = start_offset;
+  while(count <= end_offset) {
+    std::int64_t read_bytes = hdfsPread(fs, file, count, &buffer[0], buffsize);
+    if(read_bytes <= 0) {
+      //todo: add some retry logic to step over block boundary
+      break;
+    } else {
+      count += read_bytes;
+    }
+  }
+
+  end = std::chrono::system_clock::now();
+  std::chrono::duration<double> dt = end - start;
+
+  info.read_bytes = count - start_offset;
+  info.runtime = dt.count();
+
+  std::vector<char> empty_tmp;
+  buffer = empty_tmp; 
+  return info;  
+}
+
+struct scanner {
+  hdfsFS fs;
+  hdfsFile file;
+  size_t read_size;
+  off_t start;
+  off_t end;
+
+  //out
+  scan_info info;
+
+  scanner(hdfsFS fs, hdfsFile file, size_t read_size, off_t start, off_t end) : fs(fs), file(file), read_size(read_size), 
+                                                                                start(start), end(end) {};
+  void operator()(){
+    info = single_threaded_linear_scan(fs, file, read_size, start, end);
+    std::cout << info.str() << std::endl;
+  }
+
+  scan_info getResult(){
+    return info;
+  }
+};
+
+void n_threaded_linear_scan(hdfsFS fs, std::string path, int threadcount, 
+                                size_t read_size,
+                                off_t start,
+                                off_t end) 
+{
+  std::cout << "concurrency max is " << std::thread::hardware_concurrency() << std::endl;
+
+  std::vector<scanner> scanners;
+  std::vector<std::thread> threads;
+  std::vector<hdfsFile> hdfsFiles;
+
+  //spawn
+  for(int i=0; i< threadcount; i++) {
+    std::cout << "starting thread " << i << std::endl;
+    hdfsFile file = hdfsOpenFile(fs, path.c_str(), 0, 0, 0, 0);
+    hdfsFiles.push_back(file);
+    scanner s(fs, file, read_size, start, end);
+    scanners.push_back(s);
+    threads.push_back(std::thread(s));
+  }
+
+  //join
+  for(int i=0; i<threadcount; i++) {
+    std::cout << "joining thread " << i << std::endl;
+    threads[i].join();
+    hdfsCloseFile(fs, hdfsFiles[i]);
+  }
+
+}
+
+struct seeker {
+  hdfsFS fs;
+  hdfsFile file;
+  int threadcount;
+  unsigned int count;
+  off_t window_min;
+  off_t window_max;
+
+  //out
+  seek_info info;
+
+  seeker(hdfsFS fs, hdfsFile file, int threadcount, unsigned int count,  off_t window_min, off_t window_max) : fs(fs), file(file), 
+                    threadcount(threadcount), count(count), window_min(window_min), window_max(window_max) {};
+
+  void operator()(){
+    info = single_threaded_random_seek(fs, file, count, window_min, window_max);
+    std::cout << info.str() << std::endl;
+  }
+
+  seek_info getResult(){
+    return info;
+  }
+};
+
+
+
+void n_threaded_random_seek(hdfsFS fs, std::string path, int threadcount,
+                                unsigned int count,
+                                off_t window_min,
+                                off_t window_max)
+{
+  std::cout << "concurrency max is " << std::thread::hardware_concurrency() << std::endl;
+
+  std::vector<seeker> seekers;
+  std::vector<std::thread> threads;
+  std::vector<hdfsFile> hdfsFiles;
+
+
+  //spawn
+  for(int i=0; i< threadcount; i++) {
+    std::cout << "starting thread " << i << std::endl;
+    hdfsFile file = hdfsOpenFile(fs, path.c_str(), 0, 0, 0, 0);
+    hdfsFiles.push_back(file);
+    seeker s(fs, file, threadcount, count, window_min, window_max);
+    seekers.push_back(s);
+    threads.push_back(std::thread(s));
+  }
+  
+  //join
+  for(int i=0; i<threadcount; i++) {
+    std::cout << "joining thread " << i << std::endl;
+    threads[i].join();
+    hdfsCloseFile(fs, hdfsFiles[i]);
+  }
+
+}
+
+
+
+
+
+
+
+
+

--- a/src/main/native/lib/reader/CMakeLists.txt
+++ b/src/main/native/lib/reader/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(reader remote_block_reader.cc)
+add_executable(remote_block_reader_test remote_block_reader_test.cc)
+target_link_libraries(remote_block_reader_test reader proto common ${PROTOBUF_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})

--- a/src/main/native/lib/reader/block_reader.h
+++ b/src/main/native/lib/reader/block_reader.h
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef BLOCK_READER_H_
+#define BLOCK_READER_H_
+
+#include "libhdfs++/options.h"
+#include "libhdfs++/status.h"
+#include "datatransfer.pb.h"
+
+#include <memory>
+
+namespace hdfs {
+
+template<class Stream>
+class RemoteBlockReader : public std::enable_shared_from_this<RemoteBlockReader<Stream> > {
+ public:
+  explicit RemoteBlockReader(const BlockReaderOptions &options,
+                             Stream *stream)
+      : stream_(stream)
+      , state_(kOpen)
+      , options_(options)
+      , chunk_padding_bytes_(0)
+  {}
+
+  template<class MutableBufferSequence, class ReadHandler>
+  void async_read_some(const MutableBufferSequence& buffers,
+                       const ReadHandler &handler);
+
+  template<class MutableBufferSequence>
+  size_t read_some(const MutableBufferSequence &buffers, Status *status);
+
+  Status connect(const std::string &client_name,
+                 const hadoop::common::TokenProto *token,
+                 const hadoop::hdfs::ExtendedBlockProto *block,
+                 uint64_t length, uint64_t offset);
+
+  template<class ConnectHandler>
+  void async_connect(const std::string &client_name,
+                 const hadoop::common::TokenProto *token,
+                 const hadoop::hdfs::ExtendedBlockProto *block,
+                 uint64_t length, uint64_t offset,
+                 const ConnectHandler &handler);
+
+ private:
+  struct ReadPacketHeader;
+  struct ReadChecksum;
+  struct ReadPadding;
+  template<class MutableBufferSequence>
+  struct ReadData;
+  struct AckRead;
+  enum State {
+    kOpen,
+    kReadPacketHeader,
+    kReadChecksum,
+    kReadPadding,
+    kReadData,
+    kFinished,
+  };
+
+  Stream *stream_;
+  hadoop::hdfs::PacketHeaderProto header_;
+  State state_;
+  BlockReaderOptions options_;
+  size_t packet_len_;
+  int packet_data_read_bytes_;
+  int chunk_padding_bytes_;
+  long long bytes_to_read_;
+  std::vector<char> checksum_;
+};
+
+}
+
+#include "remote_block_reader_impl.h"
+
+#endif

--- a/src/main/native/lib/reader/remote_block_reader.cc
+++ b/src/main/native/lib/reader/remote_block_reader.cc
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "block_reader.h"
+
+namespace hdfs {
+
+hadoop::hdfs::OpReadBlockProto ReadBlockProto(const std::string &client_name,
+                                              bool verify_checksum,
+                                              const hadoop::common::TokenProto *token,
+                                              const hadoop::hdfs::ExtendedBlockProto *block,
+                                              uint64_t length, uint64_t offset) {
+  using namespace hadoop::hdfs;
+  using namespace hadoop::common;
+  BaseHeaderProto *base_h = new BaseHeaderProto();
+  base_h->set_allocated_block(new ExtendedBlockProto(*block));
+  if (token) {
+    base_h->set_allocated_token(new TokenProto(*token));
+  }
+  ClientOperationHeaderProto *h = new ClientOperationHeaderProto();
+  h->set_clientname(client_name);
+  h->set_allocated_baseheader(base_h);
+
+  OpReadBlockProto p;
+  p.set_allocated_header(h);
+  p.set_offset(offset);
+  p.set_len(length);
+  p.set_sendchecksums(verify_checksum);
+  // TODO: p.set_allocated_cachingstrategy();
+  return p;
+}
+
+}

--- a/src/main/native/lib/reader/remote_block_reader_impl.h
+++ b/src/main/native/lib/reader/remote_block_reader_impl.h
@@ -1,0 +1,333 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef IMPL_REMOTE_BLOCK_READER_H_
+#define IMPL_REMOTE_BLOCK_READER_H_
+
+#include "common/datatransfer.h"
+#include "common/continuation/asio.h"
+#include "common/continuation/protobuf.h"
+
+#include <asio/buffers_iterator.hpp>
+#include <asio/streambuf.hpp>
+#include <asio/write.hpp>
+
+#include <arpa/inet.h>
+
+#include <future>
+
+namespace hdfs {
+
+hadoop::hdfs::OpReadBlockProto ReadBlockProto(
+    const std::string &client_name, bool verify_checksum,
+    const hadoop::common::TokenProto *token,
+    const hadoop::hdfs::ExtendedBlockProto *block,
+    uint64_t length, uint64_t offset);
+
+template<class Stream>
+template<class ConnectHandler>
+void RemoteBlockReader<Stream>::async_connect(const std::string &client_name,
+                                              const hadoop::common::TokenProto *token,
+                                              const hadoop::hdfs::ExtendedBlockProto *block,
+                                              uint64_t length, uint64_t offset,
+                                              const ConnectHandler &handler) {
+  // The total number of bytes that we need to transfer from the DN is
+  // the amount that the user wants (bytesToRead), plus the padding at
+  // the beginning in order to chunk-align. Note that the DN may elect
+  // to send more than this amount if the read starts/ends mid-chunk.
+  bytes_to_read_ = length;
+
+  struct State {
+    std::string header;
+    hadoop::hdfs::OpReadBlockProto request;
+    hadoop::hdfs::BlockOpResponseProto response;
+  };
+
+  auto m = continuation::Pipeline<State>::Create();
+  State *s = &m->state();
+
+  s->header.insert(s->header.begin(), { 0, kDataTransferVersion, Operation::kReadBlock });
+  s->request = std::move(ReadBlockProto(client_name, options_.verify_checksum, token, block, length, offset));
+
+  auto read_pb_message = new continuation::ReadDelimitedPBMessageContinuation<Stream, 16384>(stream_, &s->response);
+
+  m->Push(continuation::Write(stream_, asio::buffer(s->header)))
+      .Push(continuation::WriteDelimitedPBMessage(stream_, &s->request))
+      .Push(read_pb_message);
+
+  m->Run([this,handler,offset](const Status &status, const State &s) {
+      Status stat = status;
+      if (stat.ok()) {
+        const auto &resp = s.response;
+        if (resp.status() == ::hadoop::hdfs::Status::SUCCESS) {
+          if(resp.has_readopchecksuminfo()) {
+            const auto& checksum_info = resp.readopchecksuminfo();
+            chunk_padding_bytes_ = offset - checksum_info.chunkoffset();
+          }
+          state_ = kReadPacketHeader;
+        } else {
+          stat = Status::Error(s.response.message().c_str());
+        }
+      }
+      handler(stat);
+      });
+}
+
+template<class Stream>
+struct RemoteBlockReader<Stream>::ReadPacketHeader : continuation::Continuation {
+  ReadPacketHeader(RemoteBlockReader<Stream> *parent)
+      : parent_(parent)
+  {}
+
+  virtual void Run(const Next& next) override {
+    parent_->packet_data_read_bytes_ = 0;
+    parent_->packet_len_ = 0;
+    auto handler = [next,this](const asio::error_code &ec, size_t) {
+      Status status;
+      if (ec) {
+        status = Status(ec.value(), ec.message().c_str());
+      } else {
+        parent_->packet_len_ = packet_length();
+        parent_->header_.Clear();
+        bool v = parent_->header_.ParseFromArray(
+            &buf_[kHeaderStart], header_length());
+        assert(v && "Failed to parse the header");
+        parent_->state_ = kReadChecksum;
+      }
+      next(status);
+    };
+
+    asio::async_read(*parent_->stream_, asio::buffer(buf_),
+                     std::bind(&ReadPacketHeader::CompletionHandler, this,
+                               std::placeholders::_1, std::placeholders::_2),
+                     handler);
+  }
+
+ private:
+  static const size_t kMaxHeaderSize = 512;
+  static const size_t kPayloadLenOffset = 0;
+  static const size_t kPayloadLenSize = sizeof(int);
+  static const size_t kHeaderLenOffset = 4;
+  static const size_t kHeaderLenSize = sizeof(short);
+  static const size_t kHeaderStart = kPayloadLenSize + kHeaderLenSize;
+
+  RemoteBlockReader<Stream> *parent_;
+  std::array<char, kMaxHeaderSize> buf_;
+
+  size_t packet_length() const
+  { return ntohl(*reinterpret_cast<const unsigned*>(&buf_[kPayloadLenOffset])); }
+
+  size_t header_length() const
+  { return ntohs(*reinterpret_cast<const short*>(&buf_[kHeaderLenOffset])); }
+
+  size_t CompletionHandler(const asio::error_code &ec, size_t transferred) {
+    if (ec) {
+      return 0;
+    } else if (transferred < kHeaderStart) {
+      return kHeaderStart - transferred;
+    } else {
+      return kHeaderStart + header_length() - transferred;
+    }
+  }
+};
+
+template<class Stream>
+struct RemoteBlockReader<Stream>::ReadChecksum : continuation::Continuation {
+  ReadChecksum(RemoteBlockReader<Stream> *parent)
+      : parent_(parent)
+  {}
+
+  virtual void Run(const Next& next) override {
+    auto parent = parent_;
+    if (parent->state_ != kReadChecksum) {
+      next(Status::OK());
+      return;
+    }
+
+    auto handler = [parent,next](const asio::error_code &ec, size_t) {
+      Status status;
+      if (ec) {
+        status = Status(ec.value(), ec.message().c_str());
+      } else {
+        parent->state_ = parent->chunk_padding_bytes_ ? kReadPadding : kReadData;
+      }
+      next(status);
+    };
+    parent->checksum_.resize(parent->packet_len_ - sizeof(int) - parent->header_.datalen());
+    asio::async_read(*parent->stream_, asio::buffer(parent->checksum_), handler);
+  }
+
+ private:
+  RemoteBlockReader<Stream> *parent_;
+};
+
+template<class Stream>
+struct RemoteBlockReader<Stream>::ReadPadding : continuation::Continuation {
+  ReadPadding(RemoteBlockReader<Stream> *parent)
+      : parent_(parent)
+      , padding_(parent->chunk_padding_bytes_)
+      , bytes_transferred_(std::make_shared<size_t>(0))
+      , read_data_(new ReadData<asio::mutable_buffers_1>(parent, bytes_transferred_, asio::buffer(padding_)))
+  {}
+
+  virtual void Run(const Next& next) override {
+    if (parent_->state_ != kReadPadding || !parent_->chunk_padding_bytes_) {
+      next(Status::OK());
+      return;
+    }
+
+    auto h = [next,this](const Status &status) {
+      if (status.ok()) {
+        assert(reinterpret_cast<const int&>(*bytes_transferred_) == parent_->chunk_padding_bytes_);
+        parent_->chunk_padding_bytes_ = 0;
+        parent_->state_ = kReadData;
+      }
+      next(status);
+    };
+    read_data_->Run(h);
+  }
+
+ private:
+  RemoteBlockReader<Stream> *parent_;
+  std::vector<char> padding_;
+  std::shared_ptr<size_t> bytes_transferred_;
+  std::shared_ptr<continuation::Continuation> read_data_;
+  ReadPadding(const ReadPadding &) = delete;
+  ReadPadding &operator=(const ReadPadding &) = delete;
+};
+
+template<class Stream>
+template<class MutableBufferSequence>
+struct RemoteBlockReader<Stream>::ReadData : continuation::Continuation {
+  ReadData(RemoteBlockReader<Stream> *parent,
+           std::shared_ptr<size_t> bytes_transferred,
+           const MutableBufferSequence &buf)
+      : parent_(parent)
+      , bytes_transferred_(bytes_transferred)
+      , buf_(buf)
+  {}
+
+  virtual void Run(const Next& next) override {
+    auto handler = [next,this](const asio::error_code &ec, size_t transferred) {
+      Status status;
+      if (ec) {
+        status = Status(ec.value(), ec.message().c_str());
+      }
+      *bytes_transferred_ += transferred;
+      parent_->bytes_to_read_ -= transferred;
+      parent_->packet_data_read_bytes_ += transferred;
+      if (parent_->packet_data_read_bytes_ >= parent_->header_.datalen()) {
+        parent_->state_ = kReadPacketHeader;
+      }
+      next(status);
+    };
+
+    auto data_len = parent_->header_.datalen() - parent_->packet_data_read_bytes_;
+    async_read(*parent_->stream_, buf_, asio::transfer_exactly(data_len), handler);
+  }
+
+ private:
+  RemoteBlockReader<Stream> *parent_;
+  std::shared_ptr<size_t> bytes_transferred_;
+  MutableBufferSequence buf_;
+};
+
+template<class Stream>
+struct RemoteBlockReader<Stream>::AckRead : continuation::Continuation {
+  AckRead(RemoteBlockReader<Stream> *parent)
+      : parent_(parent)
+  {}
+
+  virtual void Run(const Next& next) override {
+    if (parent_->bytes_to_read_ > 0) {
+      next(Status::OK());
+      return;
+    }
+
+    auto m = continuation::Pipeline<hadoop::hdfs::ClientReadStatusProto>::Create();
+    m->state().set_status(
+        parent_->options_.verify_checksum ?
+        hadoop::hdfs::Status::CHECKSUM_OK : hadoop::hdfs::Status::SUCCESS);
+
+    m->Push(continuation::WriteDelimitedPBMessage(parent_->stream_, &m->state()));
+
+    m->Run([this,next](const Status &status, const hadoop::hdfs::ClientReadStatusProto&) {
+        if (status.ok()) {
+          parent_->state_ = RemoteBlockReader<Stream>::kFinished;
+        }
+        next(status);
+      });
+  }
+
+ private:
+  RemoteBlockReader<Stream> *parent_;
+};
+
+template<class Stream>
+template<class MutableBufferSequence, class ReadHandler>
+void RemoteBlockReader<Stream>::async_read_some(const MutableBufferSequence& buffers,
+                                                const ReadHandler &handler) {
+  assert(state_ != kOpen && "Not connected");
+
+  struct State {
+    std::shared_ptr<size_t> bytes_transferred;
+  };
+  auto m = continuation::Pipeline<State>::Create();
+  m->state().bytes_transferred = std::make_shared<size_t>(0);
+
+  m->Push(new ReadPacketHeader(this))
+      .Push(new ReadChecksum(this))
+      .Push(new ReadPadding(this))
+      .Push(new ReadData<MutableBufferSequence>(this, m->state().bytes_transferred, buffers))
+      .Push(new AckRead(this));
+
+  auto self = this->shared_from_this();
+  m->Run([self,handler](const Status &status, const State &state) {
+      handler(status, *state.bytes_transferred);
+    });
+}
+
+template<class Stream>
+template<class MutableBufferSequence>
+size_t RemoteBlockReader<Stream>::read_some(const MutableBufferSequence& buffers, Status *status) {
+  size_t transferred = 0;
+  auto done = std::make_shared<std::promise<void> >();
+  auto future = done->get_future();
+  async_read_some(buffers, [status,&transferred,done](const Status &stat, size_t t) {
+      *status = stat;
+      transferred = t;
+      done->set_value();
+    });
+  future.wait();
+  return transferred;
+}
+
+template<class Stream>
+Status RemoteBlockReader<Stream>::connect(const std::string &client_name,
+                                          const hadoop::common::TokenProto *token,
+                                          const hadoop::hdfs::ExtendedBlockProto *block,
+                                          uint64_t length, uint64_t offset) {
+  auto stat = std::make_shared<std::promise<Status>>();
+  std::future<Status> future(stat->get_future());
+  async_connect(client_name, token, block, length, offset,
+                [stat](const Status &status) { stat->set_value(status); });
+  return future.get();
+}
+
+}
+
+#endif

--- a/src/main/native/lib/reader/remote_block_reader_test.cc
+++ b/src/main/native/lib/reader/remote_block_reader_test.cc
@@ -1,0 +1,54 @@
+#include "block_reader.h"
+
+#include <asio.hpp>
+
+#include <iostream>
+#include <string>
+
+int main(int argc, char *argv[]) {
+  using namespace hdfs;
+  using ::asio::ip::tcp;
+
+  if (argc != 8)
+  {
+    std::cerr
+        << "A simple client to read a block in the HDFS cluster.\n"
+        << "Usage: " << argv[0] << " "
+        << "<poolid> <blockid> <genstamp> <size> <offset> <dnhost> <dnport>\n";
+    return 1;
+  }
+
+  asio::io_service io_service;
+
+  hadoop::hdfs::ExtendedBlockProto block;
+  block.set_poolid(argv[1]);
+  block.set_blockid(std::stol(argv[2]));
+  block.set_generationstamp(std::stol(argv[3]));
+  size_t size = std::stol(argv[4]);
+  size_t offset = std::stol(argv[5]);
+
+  tcp::resolver resolver(io_service);
+  tcp::resolver::query query(tcp::v4(), argv[6], argv[7]);
+  tcp::resolver::iterator iterator = resolver.resolve(query);
+
+  std::shared_ptr<tcp::socket> s(new tcp::socket(io_service));
+  asio::connect(*s.get(), iterator);
+
+  BlockReaderOptions options;
+  auto reader = std::make_shared<RemoteBlockReader<tcp::socket> >(options, s.get());
+  std::unique_ptr<char[]> buf(new char[size]);
+  reader->async_connect("libhdfs++", nullptr, &block, size, offset, [&buf,reader,size](const Status &status) {
+      if (!status.ok()) {
+        std::cerr << "Error:" << status.code() << " " << status.ToString() << std::endl;
+      } else {
+        reader->async_read_some(asio::buffer(buf.get(), size), [&buf,size](const Status &status, size_t transferred) {
+            buf[std::min(transferred, size - 1)] = 0;
+            std::cerr << "Done:" << status.code()
+                      << " transferred = " << transferred << "\n"
+                      << buf.get() << std::endl;
+          });
+      }
+    });
+  io_service.run();
+  return 0;
+}

--- a/src/main/native/lib/rpc/CMakeLists.txt
+++ b/src/main/native/lib/rpc/CMakeLists.txt
@@ -1,0 +1,5 @@
+include_directories(${OPENSSL_INCLUDE_DIRS})
+add_library(rpc rpc_connection.cc rpc_engine.cc)
+add_executable(rpc_test rpc_test.cc)
+target_link_libraries(rpc_test rpc common proto ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+

--- a/src/main/native/lib/rpc/impl/rpc_connection.h
+++ b/src/main/native/lib/rpc/impl/rpc_connection.h
@@ -1,0 +1,137 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LIB_RPC_IMPL_RPC_CONNECTION_H_
+#define LIB_RPC_IMPL_RPC_CONNECTION_H_
+
+#include "RpcHeader.pb.h"
+
+#include "common/util.h"
+
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+
+#include <asio/connect.hpp>
+#include <asio/write.hpp>
+
+namespace hdfs {
+
+class RpcConnection::RequestBase {
+ public:
+  int call_id() const { return call_id_; }
+  ::asio::deadline_timer &timer() { return timer_; }
+  const std::string &payload() const { return payload_; }
+
+  virtual ~RequestBase();
+  virtual void OnResponseArrived(
+      ::google::protobuf::io::CodedInputStream *is,
+      const Status &status) = 0;
+
+ protected:
+  int call_id_;
+  ::asio::deadline_timer timer_;
+  std::string payload_;
+
+  RequestBase(RpcConnection *parent, const std::string &method_name,
+              const std::string &request);
+  RequestBase(RpcConnection *parent, const std::string &method_name,
+              const ::google::protobuf::MessageLite *request);
+};
+
+template <class Handler>
+class RpcConnection::Request : public RequestBase {
+ public:
+  Request(RpcConnection *parent, const std::string &method_name,
+          const std::string &request,
+          Handler &&handler)
+      : RequestBase(parent, method_name, request)
+      , handler_(std::move(handler))
+  {}
+
+  Request(RpcConnection *parent, const std::string &method_name,
+          const ::google::protobuf::MessageLite *request,
+          Handler &&handler)
+      : RequestBase(parent, method_name, request)
+      , handler_(std::move(handler))
+  {}
+
+  virtual void OnResponseArrived(::google::protobuf::io::CodedInputStream *is,
+                                 const Status &status) override
+  { handler_(is, status); }
+
+  Handler handler_;
+};
+
+template <class Iterator, class Handler>
+void RpcConnection::Connect(Iterator begin, Iterator end, const Handler &handler) {
+  ::asio::async_connect(next_layer_, begin, end,
+                        [handler](const ::asio::error_code &ec, Iterator) {
+                          handler(ToStatus(ec));
+                        });
+}
+
+template <class Handler>
+void RpcConnection::Handshake(const Handler &handler) {
+  auto handshake_packet = PrepareHandshakePacket();
+
+  ::asio::async_write(next_layer(), asio::buffer(*handshake_packet),
+                      [handshake_packet, handler](const ::asio::error_code &ec, size_t)
+                      { handler(ToStatus(ec)); });
+}
+
+
+template <class Handler>
+void RpcConnection::AsyncRpc(const std::string &method_name,
+                             const ::google::protobuf::MessageLite *req,
+                             std::shared_ptr<::google::protobuf::MessageLite> resp,
+                             const Handler &handler) {
+  auto wrapped_handler = [resp,handler](::google::protobuf::io::CodedInputStream *is, const Status &status) {
+    if (status.ok()) {
+      ReadDelimitedPBMessage(is, resp.get());
+    }
+    handler(status);
+  };
+
+  auto r = new Request<decltype(wrapped_handler)>(this, method_name, req, std::move(wrapped_handler));
+  pending_requests_.push_back(std::shared_ptr<RequestBase>(r));
+  StartWriteLoop();
+}
+
+template <class Handler>
+void RpcConnection::AsyncRawRpc(const std::string &method_name,
+                                const std::string &req,
+                                std::shared_ptr<std::string> resp,
+                                const Handler &handler) {
+  auto wrapped_handler = [this,resp,handler](::google::protobuf::io::CodedInputStream *is, const Status &status) {
+    if (status.ok()) {
+      uint32_t size = 0;
+      is->ReadVarint32(&size);
+      auto limit = is->PushLimit(size);
+      is->ReadString(resp.get(), limit);
+      is->PopLimit(limit);
+    }
+    handler(status);
+  };
+
+  auto r = new Request<decltype(wrapped_handler)>(this, method_name, req, std::move(wrapped_handler));
+  pending_requests_.push_back(std::shared_ptr<RequestBase>(r));
+  StartWriteLoop();
+}
+
+}
+
+#endif

--- a/src/main/native/lib/rpc/rpc_connection.cc
+++ b/src/main/native/lib/rpc/rpc_connection.cc
@@ -1,0 +1,240 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "rpc_engine.h"
+
+#include "RpcHeader.pb.h"
+#include "ProtobufRpcEngine.pb.h"
+#include "IpcConnectionContext.pb.h"
+
+#include "common/util.h"
+
+#include <asio/read.hpp>
+
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+
+namespace hdfs {
+
+namespace pb = ::google::protobuf;
+namespace pbio = ::google::protobuf::io;
+
+using namespace ::hadoop::common;
+using namespace ::std::placeholders;
+
+static void
+ConstructPacket(std::string *res,
+                std::initializer_list<const pb::MessageLite*> headers,
+                const std::string *request) {
+  int len = 0;
+  std::for_each(headers.begin(), headers.end(),
+                [&len](const pb::MessageLite *v) { len += DelimitedPBMessageSize(v); });
+  if (request) {
+    len += pbio::CodedOutputStream::VarintSize32(request->size()) + request->size();
+  }
+
+  int net_len = htonl(len);
+  res->reserve(res->size() + sizeof(net_len) + len);
+
+  pbio::StringOutputStream ss(res);
+  pbio::CodedOutputStream os(&ss);
+  os.WriteRaw(reinterpret_cast<const char*>(&net_len), sizeof(net_len));
+
+  uint8_t *buf = os.GetDirectBufferForNBytesAndAdvance(len);
+  assert (buf && "Cannot allocate memory");
+
+  std::for_each(headers.begin(), headers.end(), [&buf](const pb::MessageLite *v) {
+      buf = pbio::CodedOutputStream::WriteVarint32ToArray(v->ByteSize(), buf);
+      buf = v->SerializeWithCachedSizesToArray(buf);
+    });
+
+  if (request) {
+    buf = pbio::CodedOutputStream::WriteVarint32ToArray(request->size(), buf);
+    buf = os.WriteStringToArray(*request, buf);
+  }
+}
+
+static void SetRequestHeader(RpcEngine *engine, int call_id,
+                              const std::string &method_name,
+                              RpcRequestHeaderProto *rpc_header,
+                              RequestHeaderProto *req_header) {
+  rpc_header->set_rpckind(RPC_PROTOCOL_BUFFER);
+  rpc_header->set_rpcop(RpcRequestHeaderProto::RPC_FINAL_PACKET);
+  rpc_header->set_callid(call_id);
+  rpc_header->set_clientid(engine->client_name());
+
+  req_header->set_methodname(method_name);
+  req_header->set_declaringclassprotocolname(engine->protocol_name());
+  req_header->set_clientprotocolversion(engine->protocol_version());
+}
+
+RpcConnection::RequestBase::RequestBase(
+    RpcConnection *parent,
+    const std::string &method_name,
+    const std::string &request)
+    : call_id_(parent->engine_->NextCallId())
+    , timer_(parent->io_service())
+{
+  RpcRequestHeaderProto rpc_header;
+  RequestHeaderProto req_header;
+  SetRequestHeader(parent->engine_, call_id_, method_name, &rpc_header, &req_header);
+  ConstructPacket(&payload_, {&rpc_header, &req_header}, &request);
+}
+
+RpcConnection::RequestBase::RequestBase(
+    RpcConnection *parent,
+    const std::string &method_name,
+    const pb::MessageLite *request)
+    : call_id_(parent->engine_->NextCallId())
+    , timer_(parent->io_service())
+{
+  RpcRequestHeaderProto rpc_header;
+  RequestHeaderProto req_header;
+  SetRequestHeader(parent->engine_, call_id_, method_name, &rpc_header, &req_header);
+  ConstructPacket(&payload_, {&rpc_header, &req_header, request}, nullptr);
+}
+
+RpcConnection::RequestBase::~RequestBase() {}
+
+RpcConnection::ResponseState::ResponseState()
+    : state(kReadLength)
+    , length(0)
+{}
+
+RpcConnection::RpcConnection(RpcEngine *engine)
+    : engine_(engine)
+    , next_layer_(engine->io_service())
+{}
+
+::asio::io_service &RpcConnection::io_service() {
+  return engine_->io_service();
+}
+
+void RpcConnection::OnHandleWrite(const ::asio::error_code &ec, size_t) {
+  request_over_the_wire_.reset();
+  if (ec) {
+    // TODO: Current RPC has failed -- we should abandon the
+    // connection and do proper clean up
+    assert(false && "Unimplemented");
+  }
+
+  if (!pending_requests_.size()) {
+    return;
+  }
+
+  std::shared_ptr<RequestBase> req = pending_requests_.front();
+  pending_requests_.erase(pending_requests_.begin());
+  requests_on_fly_[req->call_id()] = req;
+  request_over_the_wire_ = req;
+
+  // TODO: set the timeout for the RPC request
+
+  asio::async_write(next_layer(), asio::buffer(req->payload()),
+                    std::bind(&RpcConnection::OnHandleWrite, this, _1, _2));
+}
+
+void RpcConnection::OnHandleRead(const ::asio::error_code &ec, size_t) {
+  switch (ec.value()) {
+    case 0:
+      // No errors
+      break;
+    case asio::error::operation_aborted:
+      // The event loop has been shut down. Ignore the error.
+      return;
+    default:
+      assert(false && "Unimplemented");
+  }
+
+  auto s = &response_state_;
+  if (s->state == ResponseState::kReadLength) {
+    s->state = ResponseState::kReadContent;
+    auto buf = ::asio::buffer(reinterpret_cast<char*>(&s->length),
+                              sizeof(s->length));
+    asio::async_read(next_layer(), buf,
+                     std::bind(&RpcConnection::OnHandleRead, this, _1, _2));
+
+  } else if (s->state == ResponseState::kReadContent) {
+    s->state = ResponseState::kParseResponse;
+    s->length = ntohl(s->length);
+    s->data.resize(s->length);
+    asio::async_read(next_layer(), ::asio::buffer(s->data),
+                     std::bind(&RpcConnection::OnHandleRead, this, _1, _2));
+
+  } else if (s->state == ResponseState::kParseResponse) {
+    s->state = ResponseState::kReadLength;
+    HandleRpcResponse(s->data);
+    s->data.clear();
+    StartReadLoop();
+  }
+}
+
+void RpcConnection::StartReadLoop() {
+  io_service().post(std::bind(&RpcConnection::OnHandleRead, this, ::asio::error_code(), 0));
+}
+
+void RpcConnection::StartWriteLoop() {
+  io_service().post([this]() {
+      if (!request_over_the_wire_) {
+        OnHandleWrite(::asio::error_code(), 0);
+      }});
+}
+
+void RpcConnection::HandleRpcResponse(const std::vector<char> &data) {
+  pbio::ArrayInputStream ar(&data[0], data.size());
+  pbio::CodedInputStream in(&ar);
+  in.PushLimit(data.size());
+  RpcResponseHeaderProto h;
+  ReadDelimitedPBMessage(&in, &h);
+
+  auto it = requests_on_fly_.find(h.callid());
+  if (it == requests_on_fly_.end()) {
+    // TODO: out of line RPC request
+    assert (false && "Out of line request with unknown call id");
+  }
+
+  auto req = it->second;
+  requests_on_fly_.erase(it);
+  Status stat;
+  if (h.has_exceptionclassname()) {
+    stat = Status::Exception(h.exceptionclassname().c_str(),
+                             h.errormsg().c_str());
+  }
+  req->OnResponseArrived(&in, stat);
+}
+
+std::shared_ptr<std::string> RpcConnection::PrepareHandshakePacket() {
+  static const char kHandshakeHeader[] = {'h', 'r', 'p', 'c',
+                                          RpcEngine::kRpcVersion, 0, 0};
+  auto res = std::make_shared<std::string>(kHandshakeHeader, sizeof(kHandshakeHeader));
+
+  RpcRequestHeaderProto h;
+  h.set_rpckind(RPC_PROTOCOL_BUFFER);
+  h.set_rpcop(RpcRequestHeaderProto::RPC_FINAL_PACKET);
+  h.set_callid(kCallIdConnectionContext);
+  h.set_clientid(engine_->client_name());
+
+  IpcConnectionContextProto handshake;
+  handshake.set_protocol(engine_->protocol_name());
+  ConstructPacket(res.get(), {&h, &handshake}, nullptr);
+  return res;
+}
+
+void RpcConnection::Shutdown() {
+  next_layer_.close();
+}
+
+}

--- a/src/main/native/lib/rpc/rpc_engine.cc
+++ b/src/main/native/lib/rpc/rpc_engine.cc
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "rpc_engine.h"
+
+#include "common/util.h"
+
+#include <openssl/rand.h>
+
+#include <sstream>
+#include <future>
+
+namespace hdfs {
+
+RpcEngine::RpcEngine(::asio::io_service *io_service,
+                     const std::string &client_name,
+                     const char *protocol_name, int protocol_version)
+    : io_service_(io_service)
+    , client_name_(client_name)
+    , protocol_name_(protocol_name)
+    , protocol_version_(protocol_version)
+    , call_id_(0)
+    , conn_(this)
+{}
+
+Status RpcEngine::Connect(const ::asio::ip::tcp::endpoint &server) {
+  using ::asio::ip::tcp;
+  auto stat = std::make_shared<std::promise<Status>>();
+  std::future<Status> future(stat->get_future());
+  std::vector<tcp::endpoint> ep;
+  ep.push_back(server);
+  conn_.Connect(ep.begin(), ep.end(), [this,stat](const Status &status) {
+      if (!status.ok()) {
+        stat->set_value(status);
+        return;
+      }
+      conn_.Handshake([this,stat](const Status &status) { stat->set_value(status); });
+    });
+  return future.get();
+}
+
+void RpcEngine::StartReadLoop() {
+  conn_.StartReadLoop();
+}
+
+void RpcEngine::Shutdown() {
+  io_service_->post([this]() { conn_.Shutdown(); });
+}
+
+Status RpcEngine::Rpc(const std::string &method_name,
+                      const ::google::protobuf::MessageLite *req,
+                      const std::shared_ptr<::google::protobuf::MessageLite> &resp) {
+  auto stat = std::make_shared<std::promise<Status>>();
+  std::future<Status> future(stat->get_future());
+  AsyncRpc(method_name, req, resp, [stat](const Status &status) {
+      stat->set_value(status);
+    });
+  return future.get();
+}
+
+Status RpcEngine::RawRpc(const std::string &method_name, const std::string &req,
+                         std::shared_ptr<std::string> resp) {
+  auto stat = std::make_shared<std::promise<Status>>();
+  std::future<Status> future(stat->get_future());
+  conn_.AsyncRawRpc(method_name, req, resp, [stat](const Status &status) {
+      stat->set_value(status);
+    });
+  return future.get();
+}
+
+std::string RpcEngine::GetRandomClientName() {
+  unsigned char buf[6] = {0,};
+  RAND_pseudo_bytes(buf, sizeof(buf));
+
+  std::stringstream ss;
+  ss << "libhdfs++_"
+     << Base64Encode(std::string(reinterpret_cast<char*>(buf), sizeof(buf)));
+  return ss.str();
+}
+
+}

--- a/src/main/native/lib/rpc/rpc_engine.h
+++ b/src/main/native/lib/rpc/rpc_engine.h
@@ -1,0 +1,163 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LIB_RPC_ENGINE_H_
+#define LIB_RPC_ENGINE_H_
+
+#include "libhdfs++/status.h"
+
+#include <google/protobuf/message_lite.h>
+
+#include <asio/ip/tcp.hpp>
+#include <asio/deadline_timer.hpp>
+
+#include <atomic>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace hdfs {
+
+class RpcEngine;
+
+class RpcConnection {
+ public:
+  typedef ::asio::ip::tcp::socket NextLayer;
+  RpcConnection(RpcEngine *engine);
+  template <class Iterator, class Handler>
+  void Connect(Iterator begin, Iterator end, const Handler &handler);
+  template <class Handler>
+  void Handshake(const Handler &handler);
+  void Shutdown();
+
+  template <class Handler>
+  void AsyncRpc(const std::string &method_name,
+                const ::google::protobuf::MessageLite *req,
+                std::shared_ptr<::google::protobuf::MessageLite> resp,
+                const Handler &handler);
+
+  template <class Handler>
+  void AsyncRawRpc(const std::string &method_name,
+                   const std::string &request,
+                   std::shared_ptr<std::string> resp,
+                   const Handler &handler);
+
+  NextLayer &next_layer()
+  { return next_layer_; }
+
+  void StartReadLoop();
+
+ private:
+  class RequestBase;
+  template <class Handler>
+  class Request;
+
+  RpcEngine * const engine_;
+  NextLayer next_layer_;
+  enum {
+    kCallIdAuthorizationFailed = -1,
+    kCallIdInvalid = -2,
+    kCallIdConnectionContext = -3,
+    kCallIdPing = -4
+  };
+
+  struct ResponseState {
+    enum {
+      kReadLength,
+      kReadContent,
+      kParseResponse,
+    } state;
+    unsigned length;
+    std::vector<char> data;
+    ResponseState();
+  };
+  ResponseState response_state_;
+
+  // The request being sent over the wire
+  std::shared_ptr<RequestBase> request_over_the_wire_;
+  // Requests to be sent over the wire
+  std::vector<std::shared_ptr<RequestBase> > pending_requests_;
+  // Requests that are waiting for responses
+  std::unordered_map<int, std::shared_ptr<RequestBase> > requests_on_fly_;
+
+  template <class Handler>
+  void StartRpc(std::string &&request, const Handler &handler);
+
+  ::asio::io_service &io_service();
+  std::shared_ptr<std::string> PrepareHandshakePacket();
+  static std::string SerializeRpcRequest(const std::string &method_name, const ::google::protobuf::MessageLite *req);
+  void HandleRpcResponse(const std::vector<char> &data);
+  void OnHandleWrite(const ::asio::error_code &ec, size_t transferred);
+  void OnHandleRead(const ::asio::error_code &ec, size_t transferred);
+  void StartWriteLoop();
+};
+
+class RpcEngine {
+ public:
+  enum {
+    kRpcVersion = 9
+  };
+
+  RpcEngine(::asio::io_service *io_service,
+            const std::string &client_name,
+            const char *protocol_name, int protocol_version);
+
+  template <class Handler>
+  void AsyncRpc(const std::string &method_name,
+                const ::google::protobuf::MessageLite *req,
+                const std::shared_ptr<::google::protobuf::MessageLite> &resp,
+                const Handler &handler) {
+    conn_.AsyncRpc(method_name, req, resp, handler);
+  }
+
+  Status Rpc(const std::string &method_name,
+             const ::google::protobuf::MessageLite *req,
+             const std::shared_ptr<::google::protobuf::MessageLite> &resp);
+  /**
+   * Send raw bytes as RPC payload. This is intended to be used in JNI
+   * bindings only.
+   **/
+  Status RawRpc(const std::string &method_name, const std::string &req,
+                std::shared_ptr<std::string> resp);
+  Status Connect(const ::asio::ip::tcp::endpoint &server);
+  void StartReadLoop();
+  void Shutdown();
+
+  int NextCallId()
+  { return ++call_id_; }
+
+  const std::string &client_name() const { return client_name_; }
+  const std::string &protocol_name() const { return protocol_name_; }
+  int protocol_version() const { return protocol_version_; }
+  RpcConnection &connection() { return conn_; }
+  ::asio::io_service &io_service() { return *io_service_; }
+
+  static std::string GetRandomClientName();
+ private:
+  ::asio::io_service *io_service_;
+  const std::string client_name_;
+  const std::string protocol_name_;
+  const int protocol_version_;
+  std::atomic_int call_id_;
+  RpcConnection conn_;
+};
+
+}
+
+#include "impl/rpc_connection.h"
+
+#endif

--- a/src/main/native/lib/rpc/rpc_test.cc
+++ b/src/main/native/lib/rpc/rpc_test.cc
@@ -1,0 +1,56 @@
+#include "rpc_engine.h"
+#include "ClientNamenodeProtocol.pb.h"
+
+#include <asio.hpp>
+#include <iostream>
+
+int main(int argc, char *argv[]) {
+  using namespace hdfs;
+  using namespace ::hadoop::hdfs;
+  using ::asio::ip::tcp;
+
+  ::asio::io_service io_service;
+  if (argc != 4) {
+    std::cerr
+        << "Test whehter a file exists on the HDFS cluster.\n"
+        << "Usage: " << argv[0] << " "
+        << "<nnhost> <nnport> <file>\n";
+    return 1;
+  }
+
+  RpcEngine engine(&io_service, "libhdfs++", "org.apache.hadoop.hdfs.protocol.ClientProtocol", 1);
+  GetFileInfoRequestProto req;
+  auto resp = std::make_shared<GetFileInfoResponseProto>();
+  req.set_src(argv[3]);
+
+  RpcConnection *conn = &engine.connection();
+
+  tcp::resolver resolver(io_service);
+  tcp::resolver::query query(tcp::v4(), argv[1], argv[2]);
+  tcp::resolver::iterator iterator = resolver.resolve(query);
+
+  conn->Connect(iterator, tcp::resolver::iterator(), [conn,&req,resp,&io_service](const Status &status) {
+      if (!status.ok()) {
+        std::cerr << "Connection failed: "<< status.ToString() << std::endl;
+        return;
+      }
+      conn->Handshake([conn,&req,resp,&io_service](const Status &status) {
+          if (!status.ok()) {
+            std::cerr << "Handshake failed: "<< status.ToString() << std::endl;
+            return;
+          }
+          conn->StartReadLoop();
+          conn->AsyncRpc("getFileInfo", &req, resp, [resp,&io_service](const Status &status) {
+              if (!status.ok()) {
+                std::cerr << "Async RPC Failed: "<< status.ToString() << std::endl;
+                io_service.post([&io_service](){ io_service.stop(); });
+                return;
+              }
+              std::cerr << "File exists: " << resp->has_fs() << std::endl;
+              io_service.post([&io_service](){ io_service.stop(); });
+            });
+        });
+    });
+  io_service.run();
+  return 0;
+}

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,19 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License. See accompanying LICENSE file.
+#
+log4j.rootLogger=INFO, stdout
+ 
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n

--- a/src/test/java/me/haohui/libhdfspp/TestInputStream.java
+++ b/src/test/java/me/haohui/libhdfspp/TestInputStream.java
@@ -1,0 +1,121 @@
+package me.haohui.libhdfspp;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestInputStream {
+  private static final int MIN_BLOCK_SIZE = 1024;
+  private static MiniDFSCluster cluster;
+
+  @BeforeClass
+  public static void setUp() throws IOException {
+    HdfsConfiguration conf = new HdfsConfiguration();
+    conf.setInt(DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY, MIN_BLOCK_SIZE);
+
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+  }
+
+  @AfterClass
+  public static void tearDown() throws InterruptedException, IOException {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testReadMultiplePackets() throws IOException, InterruptedException {
+    final int PACKET_SIZE = 65536;
+    final int FILE_SIZE = 4 * PACKET_SIZE;
+    final byte[] contents = new byte[FILE_SIZE];
+    final int OFFSET_IN_TRUNK = 1;
+
+    Random rand = new Random();
+    rand.nextBytes(contents);
+    try (OutputStream os = cluster.getFileSystem().create(new Path("/foo"))) {
+      os.write(contents);
+    }
+    try (NativeIoService ioService = new NativeIoService();
+         IoServiceExecutor executor = new IoServiceExecutor(ioService)) {
+      executor.start();
+      try (NativeFileSystem fs = new NativeFileSystem(ioService, cluster
+             .getNameNode().getNameNodeAddress())) {
+        ByteBuffer buf = ByteBuffer.allocateDirect(FILE_SIZE);
+        try (NativeInputStream is = fs.open(new Path("/foo"))) {
+          int r = is.positionRead(buf, 0);
+          assertEquals(FILE_SIZE, r);
+          buf.flip();
+          assertEquals(FILE_SIZE, buf.remaining());
+          byte[] readContents = new byte[buf.remaining()];
+          buf.get(readContents);
+          Assert.assertArrayEquals(contents, readContents);
+        }
+
+        // Read in the middle of the chunk
+        buf = ByteBuffer.allocateDirect(FILE_SIZE - OFFSET_IN_TRUNK);
+        try (NativeInputStream is = fs.open(new Path("/foo"))) {
+          int r = is.positionRead(buf, OFFSET_IN_TRUNK);
+          assertEquals(FILE_SIZE - OFFSET_IN_TRUNK, r);
+          buf.flip();
+          assertEquals(FILE_SIZE - OFFSET_IN_TRUNK, buf.remaining());
+          byte[] readContents = new byte[buf.remaining()];
+          buf.get(readContents);
+          byte[] cont = new byte[FILE_SIZE - OFFSET_IN_TRUNK];
+          System.arraycopy(contents, OFFSET_IN_TRUNK, cont, 0, cont.length);
+          Assert.assertArrayEquals(cont, readContents);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testReadMultipleBlocks() throws IOException, InterruptedException {
+    final int BLOCK_SIZE = 128 * 1024;
+    final int FILE_SIZE = 2 * BLOCK_SIZE;
+    final byte[] contents = new byte[FILE_SIZE];
+    final Path path = new Path("/multi-block");
+    Random rand = new Random();
+    rand.nextBytes(contents);
+
+    try (OutputStream os = cluster.getFileSystem()
+        .create(path, true, 8192, (short) 1, BLOCK_SIZE)) {
+      os.write(contents);
+    }
+    try (NativeIoService ioService = new NativeIoService();
+         IoServiceExecutor executor = new IoServiceExecutor(ioService)) {
+      executor.start();
+      try (NativeFileSystem fs = new NativeFileSystem(ioService, cluster
+          .getNameNode().getNameNodeAddress())) {
+        ByteBuffer buf = ByteBuffer.allocateDirect(FILE_SIZE);
+        try (NativeInputStream is = fs.open(path)) {
+          long pos = 0;
+          while (pos < FILE_SIZE) {
+            int r = is.positionRead(buf, pos);
+            Assert.assertTrue(r >= 0 && r <= FILE_SIZE);
+            pos += r;
+          }
+
+          assertEquals(FILE_SIZE, pos);
+          buf.flip();
+          assertEquals(FILE_SIZE, buf.remaining());
+          byte[] readContents = new byte[buf.remaining()];
+          buf.get(readContents);
+          Assert.assertArrayEquals(contents, readContents);
+        }
+      }
+    }
+  }
+
+}

--- a/src/test/java/me/haohui/libhdfspp/TestRemoteBlockReader.java
+++ b/src/test/java/me/haohui/libhdfspp/TestRemoteBlockReader.java
@@ -1,0 +1,181 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.haohui.libhdfspp;
+
+import com.google.common.base.Charsets;
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.HdfsBlockLocation;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.protocol.ExtendedBlock;
+import org.apache.hadoop.hdfs.protocol.LocatedBlock;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.*;
+
+public class TestRemoteBlockReader {
+  private static MiniDFSCluster cluster;
+  private static DistributedFileSystem fs;
+  private static final String FILENAME = "/foo";
+  private static byte[] CONTENTS;
+  private static final int BLOCK_SIZE = 1024;
+  private static final int CONTENT_SIZE = 2 * BLOCK_SIZE;
+  private static final byte[] CLIENT_NAME =
+      "libhdfs++".getBytes(Charsets.UTF_8);
+
+  @BeforeClass
+  public static void setUp() throws IOException {
+    HdfsConfiguration conf = new HdfsConfiguration();
+    conf.setInt(DFSConfigKeys.DFS_NAMENODE_MIN_BLOCK_SIZE_KEY, BLOCK_SIZE);
+    conf.setInt(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCK_SIZE);
+
+    byte[] chars = generateCharacterTable();
+    CONTENTS = new byte[CONTENT_SIZE];
+    for (int i = 0; i < CONTENT_SIZE; ++i) {
+      CONTENTS[i] = chars[i % chars.length];
+    }
+
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(1).build();
+    fs = cluster.getFileSystem();
+    OutputStream os = fs.create(new Path(FILENAME));
+    os.write(CONTENTS);
+    os.close();
+  }
+
+  @AfterClass
+  public static void tearDown() throws InterruptedException, IOException {
+    if (fs != null) {
+      fs.close();
+    }
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Rule
+  public Timeout timeout = new Timeout(300000);
+
+  @Test
+  public void testReadWholeBlock() throws IOException, InterruptedException {
+    int readLength = BLOCK_SIZE;
+    int readOffset = 0;
+    LocatedBlock lb = getFirstLocatedBlock();
+    testReadBlockCase(lb, readOffset, readLength);
+  }
+
+  @Test
+  public void testReadAtChecksumBoundary() throws IOException, InterruptedException {
+    //Test whether it can read from the middle of the checksum chunk (512)
+    int readLength = BLOCK_SIZE / 4;
+    int readOffset = BLOCK_SIZE / 8;
+    LocatedBlock lb = getFirstLocatedBlock();
+    testReadBlockCase(lb, readOffset, readLength);
+  }
+
+  @Test
+  public void testReadFromOffsetZero() throws IOException, InterruptedException {
+    int readLength = BLOCK_SIZE - 1;
+    int readOffset = 0;
+    LocatedBlock lb = getFirstLocatedBlock();
+    testReadBlockCase(lb, readOffset, readLength);
+  }
+
+  @Test
+  public void testReadZeroByte() throws IOException, InterruptedException {
+    int readLength = 0;
+    int readOffset = 0;
+    LocatedBlock lb = getFirstLocatedBlock();
+    testReadBlockCase(lb, readOffset, readLength);
+  }
+
+  @Test
+  public void testReadOneByte() throws IOException, InterruptedException {
+    int readLength = 0;
+    int readOffset = 1;
+    LocatedBlock lb = getFirstLocatedBlock();
+    testReadBlockCase(lb, readOffset, readLength);
+  }
+
+  private void testReadBlockCase(
+      LocatedBlock lb, int readOffset, int readLength)
+      throws IOException, InterruptedException {
+    ExtendedBlock eb = lb.getBlock();
+    try (NativeIoService ioService = new NativeIoService();
+         IoServiceExecutor executor = new IoServiceExecutor(ioService);
+         NativeTcpConnection conn = new NativeTcpConnection(ioService)
+    ) {
+      executor.start();
+      conn.connect(cluster.getDataNodes().get(0).getXferAddress());
+      try (NativeRemoteBlockReader reader = new NativeRemoteBlockReader
+          (conn)) {
+        reader.connect(CLIENT_NAME, null, eb, readLength, readOffset);
+        ByteBuffer buf = ByteBuffer.allocateDirect(readLength);
+        int transferred = reader.read(buf);
+        assertEquals(readLength, transferred);
+        buf.flip();
+        byte[] data = new byte[readLength];
+        buf.get(data);
+        byte[] origData = new byte[readLength];
+        System.arraycopy(CONTENTS, readOffset, origData, 0, readLength);
+        assertArrayEquals(origData, data);
+      }
+    }
+  }
+
+  private LocatedBlock getFirstLocatedBlock() throws IOException {
+    BlockLocation[] locs = fs.getFileBlockLocations(new Path(FILENAME), 0,
+                                                    CONTENT_SIZE);
+    return ((HdfsBlockLocation) locs[0]).getLocatedBlock();
+  }
+
+  private static byte[] generateCharacterTable() {
+    byte[] chars = new byte[64];
+    for (int i = 0; i < 10; ++i) {
+      chars[i] = (byte) ('0' + i);
+    }
+    for (int i = 0; i < 26; ++i) {
+      chars[i + 10] = (byte) ('a' + i);
+    }
+    for (int i = 0; i < 26; ++i) {
+      chars[i + 36] = (byte) ('A' + i);
+    }
+    chars[62] = '/';
+    chars[63] = '+';
+    return chars;
+  }
+
+  @Test
+  public void testReadIntoChecksumChunk() throws IOException, InterruptedException {
+    int readLength = BLOCK_SIZE / 4;
+    int readOffset = 11;
+    LocatedBlock lb = getFirstLocatedBlock();
+    testReadBlockCase(lb, readOffset, readLength);
+  }
+
+}

--- a/src/test/java/me/haohui/libhdfspp/TestRpcEngine.java
+++ b/src/test/java/me/haohui/libhdfspp/TestRpcEngine.java
@@ -1,0 +1,230 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.haohui.libhdfspp;
+
+import com.google.protobuf.BlockingService;
+import com.google.protobuf.MessageLite;
+import com.google.protobuf.RpcController;
+import com.google.protobuf.ServiceException;
+import org.apache.commons.io.Charsets;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.ipc.ProtobufRpcEngine;
+import org.apache.hadoop.ipc.ProtocolInfo;
+import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.ipc.RemoteException;
+import org.apache.hadoop.ipc.RpcServerException;
+import org.apache.hadoop.ipc.Server;
+import org.apache.hadoop.ipc.protobuf.RpcHeaderProtos.RpcResponseHeaderProto.*;
+import org.apache.hadoop.net.NetUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+import me.haohui.libhdfspp.TestRpcServiceProtos.*;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestRpcEngine {
+  private static final byte[] CLIENT_ID = "libhdfspp".getBytes(Charsets.UTF_8);
+  private final static String ADDRESS = "localhost";
+  private final static int PORT = 0;
+  private static InetSocketAddress addr;
+  private static Configuration conf;
+  private static RPC.Server server;
+  private static final NativeIoService ioService = new NativeIoService();
+  private static final IoServiceExecutor executor = new IoServiceExecutor
+      (ioService);
+
+  @ProtocolInfo(protocolName = "testProto", protocolVersion = 1)
+  public interface TestRpcService
+      extends TestRpcServiceProtos.TestProtobufRpcProto.BlockingInterface {
+  }
+
+  static class NativeRPCClient implements TestRpcService, Closeable {
+    private final NativeRpcEngine engine;
+
+    NativeRPCClient(NativeRpcEngine engine) {
+      this.engine = engine;
+    }
+
+    private void rpc(String method, MessageLite request,
+        MessageLite.Builder response) throws ServiceException {
+      try {
+        engine.rpc(method.getBytes(Charsets.UTF_8), request, response);
+      } catch (IOException e) {
+        throw new ServiceException(e);
+      }
+    }
+
+    @Override
+    public EmptyResponseProto ping(
+        RpcController controller, EmptyRequestProto request)
+        throws ServiceException {
+      EmptyResponseProto.Builder b = EmptyResponseProto.newBuilder();
+      rpc("ping", request, b);
+      return b.build();
+    }
+
+    @Override
+    public EchoResponseProto echo(
+        RpcController controller, EchoRequestProto request)
+        throws ServiceException {
+      EchoResponseProto.Builder b = EchoResponseProto.newBuilder();
+      rpc("echo", request, b);
+      return b.build();
+    }
+
+    @Override
+    public EmptyResponseProto error(
+        RpcController controller, EmptyRequestProto request)
+        throws ServiceException {
+      EmptyResponseProto.Builder b = EmptyResponseProto.newBuilder();
+      rpc("error", request, b);
+      return b.build();
+    }
+
+    @Override
+    public EmptyResponseProto error2(
+        RpcController controller, EmptyRequestProto request)
+        throws ServiceException {
+      EmptyResponseProto.Builder b = EmptyResponseProto.newBuilder();
+      rpc("error2", request, b);
+      return b.build();
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+  }
+
+  public static class PBServerImpl implements TestRpcService {
+    @Override
+    public EmptyResponseProto ping(RpcController unused,
+        EmptyRequestProto request) throws ServiceException {
+      byte[] clientId = Server.getClientId();
+      Assert.assertArrayEquals(CLIENT_ID, clientId);
+      return EmptyResponseProto.newBuilder().build();
+    }
+
+    @Override
+    public EchoResponseProto echo(RpcController unused, EchoRequestProto request)
+        throws ServiceException {
+      return EchoResponseProto.newBuilder().setMessage(request.getMessage())
+          .build();
+    }
+
+    @Override
+    public EmptyResponseProto error(RpcController unused,
+        EmptyRequestProto request) throws ServiceException {
+      throw new ServiceException("error", new RpcServerException("error"));
+    }
+
+    @Override
+    public EmptyResponseProto error2(RpcController unused,
+        EmptyRequestProto request) throws ServiceException {
+      throw new ServiceException("error", new RuntimeException("testException"));
+    }
+  }
+
+  @BeforeClass
+  public static void setUp() throws IOException {
+    conf = new Configuration();
+    conf.setInt(CommonConfigurationKeys.IPC_MAXIMUM_DATA_LENGTH, 1024);
+    // Set RPC engine to protobuf RPC engine
+    RPC.setProtocolEngine(conf, TestRpcService.class, ProtobufRpcEngine.class);
+
+    // Create server side implementation
+    PBServerImpl serverImpl = new PBServerImpl();
+    BlockingService service = TestRpcServiceProtos.TestProtobufRpcProto
+        .newReflectiveBlockingService(serverImpl);
+
+    // Get RPC server for server side implementation
+    server = new RPC.Builder(conf).setProtocol(TestRpcService.class)
+        .setInstance(service).setBindAddress(ADDRESS).setPort(PORT).build();
+    addr = NetUtils.getConnectAddress(server);
+    server.start();
+    executor.start();
+  }
+
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    if (server != null) {
+      server.stop();
+    }
+    executor.close();
+    ioService.close();
+  }
+
+  @Test (timeout=5000)
+  public void testProtoBufRpc() throws Exception {
+    try (NativeRpcEngine engine = new NativeRpcEngine(
+        ioService, CLIENT_ID, "testProto", 1);
+    ) {
+      engine.connect(addr);
+      engine.startReadLoop();
+      TestRpcService client = new NativeRPCClient(engine);
+      testProtoBufRpc(client);
+    }
+  }
+
+  // separated test out so that other tests can call it.
+  public static void testProtoBufRpc(TestRpcService client) throws Exception {
+    // Test ping method
+    EmptyRequestProto emptyRequest = EmptyRequestProto.newBuilder().build();
+    client.ping(null, emptyRequest);
+
+    // Test echo method
+    EchoRequestProto echoRequest = EchoRequestProto.newBuilder()
+        .setMessage("hello").build();
+    EchoResponseProto echoResponse = client.echo(null, echoRequest);
+    Assert.assertEquals(echoResponse.getMessage(), "hello");
+
+    // Test error method - error should be thrown as RemoteException
+    try {
+      client.error(null, emptyRequest);
+      Assert.fail("Expected exception is not thrown");
+    } catch (ServiceException ignored) {
+    }
+  }
+
+  @Test(timeout=5000)
+  public void testProtoBufRandomException() throws Exception {
+    try (NativeRpcEngine engine = new NativeRpcEngine(
+        ioService, CLIENT_ID, "testProto", 1);
+    ) {
+      engine.connect(addr);
+      engine.startReadLoop();
+      TestRpcService client = new NativeRPCClient(engine);
+      EmptyRequestProto emptyRequest = EmptyRequestProto.newBuilder().build();
+
+      try {
+        client.error2(null, emptyRequest);
+        Assert.fail("Expected exception is not thrown");
+      } catch (ServiceException ignored) {
+      }
+    }
+  }
+}

--- a/src/test/proto/test_rpc_service.proto
+++ b/src/test/proto/test_rpc_service.proto
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "me.haohui.libhdfspp";
+option java_outer_classname = "TestRpcServiceProtos";
+option java_generic_services = true;
+option java_generate_equals_and_hash = true;
+package hdfs;
+
+message EmptyRequestProto {
+}
+
+message EmptyResponseProto {
+}
+
+message EchoRequestProto {
+  required string message = 1;
+}
+
+message EchoResponseProto {
+  required string message = 1;
+}
+
+/**
+ * A protobuf service for use in tests
+ */
+service TestProtobufRpcProto {
+  rpc ping(EmptyRequestProto) returns (EmptyResponseProto);
+  rpc echo(EchoRequestProto) returns (EchoResponseProto);
+  rpc error(EmptyRequestProto) returns (EmptyResponseProto);
+  rpc error2(EmptyRequestProto) returns (EmptyResponseProto);
+}


### PR DESCRIPTION
Added 3 tests that talk to libhdfs++ through the libhdfs(3) shim layer. 
threaded_seek test:  Open N threads and have them do 1 byte reads at random offsets on a specified range in the file.  

threaded_scan test:  Open N threads and have them all do sequential reads through the file until they hit a specified stop offset.  The size of the reads can also be specified to see performance impact of large vs small reads.  I've used this and the threaded_seek test to reproduce memory and threading issues.

open_read_close test:  Opens a file and reads a byte from a random offset within specified range then closes and repeats N times.  I usually use this to check for resource leaks.

Everything is additive on top of the libhdfs shim layer and doesn't use the JVM/JNI framework in order to make it easy to run valgrind and diagnostic tools.
