### PR TITLE
Fix for #39

### DIFF
--- a/src/main/native/lib/rpc/impl/rpc_connection.h
+++ b/src/main/native/lib/rpc/impl/rpc_connection.h
@@ -99,6 +99,8 @@ void RpcConnection::AsyncRpc(const std::string &method_name,
                              const ::google::protobuf::MessageLite *req,
                              std::shared_ptr<::google::protobuf::MessageLite> resp,
                              const Handler &handler) {
+  std::lock_guard<std::mutex> state_lock(engine_state_lock_);
+
   auto wrapped_handler = [resp,handler](::google::protobuf::io::CodedInputStream *is, const Status &status) {
     if (status.ok()) {
       ReadDelimitedPBMessage(is, resp.get());
@@ -116,6 +118,8 @@ void RpcConnection::AsyncRawRpc(const std::string &method_name,
                                 const std::string &req,
                                 std::shared_ptr<std::string> resp,
                                 const Handler &handler) {
+  std::lock_guard<std::mutex> state_lock(engine_state_lock_);
+
   auto wrapped_handler = [this,resp,handler](::google::protobuf::io::CodedInputStream *is, const Status &status) {
     if (status.ok()) {
       uint32_t size = 0;

--- a/src/main/native/lib/rpc/rpc_connection.cc
+++ b/src/main/native/lib/rpc/rpc_connection.cc
@@ -125,6 +125,8 @@ RpcConnection::RpcConnection(RpcEngine *engine)
 }
 
 void RpcConnection::OnHandleWrite(const ::asio::error_code &ec, size_t) {
+  std::lock_guard<std::mutex> state_lock(engine_state_lock_);
+
   request_over_the_wire_.reset();
   if (ec) {
     // TODO: Current RPC has failed -- we should abandon the
@@ -148,6 +150,8 @@ void RpcConnection::OnHandleWrite(const ::asio::error_code &ec, size_t) {
 }
 
 void RpcConnection::OnHandleRead(const ::asio::error_code &ec, size_t) {
+  std::lock_guard<std::mutex> state_lock(engine_state_lock_);
+
   switch (ec.value()) {
     case 0:
       // No errors
@@ -194,6 +198,7 @@ void RpcConnection::StartWriteLoop() {
 }
 
 void RpcConnection::HandleRpcResponse(const std::vector<char> &data) {
+  /* assumed to be called from a context that has already acquired the engine_state_lock */
   pbio::ArrayInputStream ar(&data[0], data.size());
   pbio::CodedInputStream in(&ar);
   in.PushLimit(data.size());

--- a/src/main/native/lib/rpc/rpc_engine.h
+++ b/src/main/native/lib/rpc/rpc_engine.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <unordered_map>
 #include <vector>
+#include <mutex>
 
 namespace hdfs {
 
@@ -93,6 +94,9 @@ class RpcConnection {
   std::vector<std::shared_ptr<RequestBase> > pending_requests_;
   // Requests that are waiting for responses
   std::unordered_map<int, std::shared_ptr<RequestBase> > requests_on_fly_;
+  // Lock for mutable parts of this class that need to be thread safe
+  std::mutex engine_state_lock_;
+
 
   template <class Handler>
   void StartRpc(std::string &&request, const Handler &handler);


### PR DESCRIPTION
Fix for #39 Added a lock on operations that change shared state of the RPC engine.  Engine is now thread safe for multiple callers and multiple threads handling io_service callbacks.

Verified to work on the unit tests and large concurrent workloads.  Please let me know if you think I'm missing anything.
