### PR TITLE
Fix for #42, run protoc first

### DIFF
--- a/src/main/native/lib/CMakeLists.txt
+++ b/src/main/native/lib/CMakeLists.txt
@@ -1,6 +1,6 @@
+add_subdirectory(proto)
 add_subdirectory(common)
 add_subdirectory(fs)
 add_subdirectory(reader)
 add_subdirectory(rpc)
-add_subdirectory(proto)
 


### PR DESCRIPTION
#42 make sure protobuf messages are compiled before anything else; at least when running a single threaded build.
