### PR TITLE
Fix #42, compile proto firstly

### DIFF
--- a/src/main/native/lib/common/CMakeLists.txt
+++ b/src/main/native/lib/common/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(common hdfs.cc base64.cc datatransfer_sasl.cc sasl_digest_md5.cc status.cc)
+add_dependencies(common proto)
 add_executable(sasl_digest_md5_test sasl_digest_md5_test.cc)
 target_link_libraries(sasl_digest_md5_test common ${OPENSSL_LIBRARIES} gtest_main)
 add_test(sasl_digest_md5_test sasl_digest_md5_test)

--- a/src/main/native/lib/fs/CMakeLists.txt
+++ b/src/main/native/lib/fs/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_library(fs filesystem.cc inputstream.cc)
+add_dependencies(fs proto)
 add_executable(inputstream_test inputstream_test.cc)
 target_link_libraries(inputstream_test fs rpc reader common proto ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})

--- a/src/main/native/lib/reader/CMakeLists.txt
+++ b/src/main/native/lib/reader/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_library(reader remote_block_reader.cc)
+add_dependencies(reader proto)
 add_executable(remote_block_reader_test remote_block_reader_test.cc)
 target_link_libraries(remote_block_reader_test reader proto common ${PROTOBUF_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})

--- a/src/main/native/lib/rpc/CMakeLists.txt
+++ b/src/main/native/lib/rpc/CMakeLists.txt
@@ -1,5 +1,6 @@
 include_directories(${OPENSSL_INCLUDE_DIRS})
 add_library(rpc rpc_connection.cc rpc_engine.cc)
+add_dependencies(rpc proto)
 add_executable(rpc_test rpc_test.cc)
 target_link_libraries(rpc_test rpc common proto ${PROTOBUF_LIBRARIES} ${OPENSSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 


### PR DESCRIPTION
As #43 suggested, using `add_dependencies(<target> [<target-dependency>]...` to solve the cmake compilation order issue. Ensure that protobuf messages are compiled before anything else.
