### PR TITLE
Added travis ci instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: cpp
+
+compiler:
+        - clang
+        - gcc
+
+matrix:
+        allow_failures:
+                - compiler: clang
+
+before_install:
+        - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        - sudo apt-get update -qq
+        - sudo apt-get install
+
+install:
+        - sudo apt-get install -qq g++-4.8
+        - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+        - sudo apt-get install -y libssl-dev protobuf-compiler libprotobuf-dev libboost-date-time-dev
+        - echo $CC
+ 
+script: ./scripts/travis_build.sh

--- a/scripts/travis_build.sh
+++ b/scripts/travis_build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ev
+
+cd src/main/native/
+rm -rf build
+mkdir -p build
+cd build
+cmake ..
+make

--- a/src/main/native/CMakeLists.txt
+++ b/src/main/native/CMakeLists.txt
@@ -36,6 +36,9 @@ if(APPLE)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wno-deprecated-declarations")
 endif()
 
+#Boost doesn't do std::chrono correcltly with clang
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_ASIO_DISABLE_STD_CHRONO")
+
 if(DOXYGEN_FOUND)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doc/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/doc/Doxyfile @ONLY)
 add_custom_target(doc ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/doc/Doxyfile


### PR DESCRIPTION
Added first stab at travis CI builds

Travis: added required packages

Travis: fixed package names

Travis: used ubuntu package names

Travis: added protobuf-compiler package

Travis: added boost date-time

Travis: dump boost dir

Travis: do apt-get install before compile for C++11?

Travis: explicitly add g++4.8

Travis: used update-alternatives rather than export CC

Travis: removed listing boost

Added BOOST_ASIO_DISABLE_STD_CHRONO for clang support

Travis: allow failure under clang
